### PR TITLE
Add slide transitions and decompose courtroom presenter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,6 +420,8 @@ add_library(ao_game STATIC
     plugins/ao/asset/AOCharacterSheet.cpp
     plugins/ao/game/AOBlipPlayer.cpp
     plugins/ao/game/AOCourtroomPresenter.cpp
+    plugins/ao/game/AOSceneCompositor.cpp
+    plugins/ao/game/AOMessagePlayer.cpp
     plugins/ao/game/AOMusicPlayer.cpp
     plugins/ao/game/ICMessageQueue.cpp
     plugins/ao/game/AOBackground.cpp
@@ -427,6 +429,7 @@ add_library(ao_game STATIC
     plugins/ao/game/AOTextBox.cpp
     plugins/ao/game/AOTextProcessor.cpp
     plugins/ao/game/effects/ScreenshakeEffect.cpp
+    plugins/ao/game/effects/SlideEffect.cpp
     plugins/ao/game/effects/FlashEffect.cpp
     plugins/ao/game/effects/ShaderEffect.cpp
 )

--- a/apps/sdl/ui/controllers/CourtroomController.cpp
+++ b/apps/sdl/ui/controllers/CourtroomController.cpp
@@ -353,6 +353,13 @@ void CourtroomController::render() {
 
     ImGui::End();
 
+    // Keep presenter in sync with local player state (slide checkbox, char_id)
+    {
+        auto& ctx = DebugContext::instance();
+        if (ctx.presenter)
+            ctx.presenter->set_local_player(ic_state_.char_id, ic_state_.slide);
+    }
+
     // Floating debug window (toggled by /debug)
     if (debug_open_) {
         ImGui::SetNextWindowSize(ImVec2(420, 600), ImGuiCond_FirstUseEver);

--- a/apps/sdl/ui/widgets/ICChatWidget.cpp
+++ b/apps/sdl/ui/widgets/ICChatWidget.cpp
@@ -39,6 +39,7 @@ void ICChatWidget::send() {
     data.realization = state_->realization ? 1 : 0;
     data.screenshake = state_->screenshake ? 1 : 0;
     data.additive = state_->additive ? 1 : 0;
+    data.slide = state_->slide ? "1" : "0";
 
     EventManager::instance().get_channel<OutgoingICMessageEvent>().publish(OutgoingICMessageEvent(std::move(data)));
 

--- a/apps/sdl/ui/widgets/ICMessageState.h
+++ b/apps/sdl/ui/widgets/ICMessageState.h
@@ -40,4 +40,5 @@ struct ICMessageState {
     bool realization = false;
     bool screenshake = false;
     bool additive = false;
+    bool slide = false;
 };

--- a/apps/sdl/ui/widgets/MessageOptionsWidget.cpp
+++ b/apps/sdl/ui/widgets/MessageOptionsWidget.cpp
@@ -18,6 +18,8 @@ void MessageOptionsWidget::render() {
     ImGui::Checkbox("Screenshake", &state_->screenshake);
     ImGui::SameLine();
     ImGui::Checkbox("Additive", &state_->additive);
+    ImGui::SameLine();
+    ImGui::Checkbox("Slide", &state_->slide);
 
     ImGui::Combo("Text Color", &state_->text_color, COLOR_LABELS, COLOR_COUNT);
 }

--- a/engine/render/RenderState.cpp
+++ b/engine/render/RenderState.cpp
@@ -11,6 +11,11 @@ LayerGroup RenderState::get_layer_group(int id) {
     return layer_groups.at(id);
 }
 
+LayerGroup* RenderState::get_mutable_layer_group(int id) {
+    auto it = layer_groups.find(id);
+    return it != layer_groups.end() ? &it->second : nullptr;
+}
+
 const std::map<int, LayerGroup>& RenderState::get_layer_groups() const {
     return layer_groups;
 }

--- a/engine/render/TransformAnimator.cpp
+++ b/engine/render/TransformAnimator.cpp
@@ -51,6 +51,12 @@ float TransformAnimator::ease(float t) const {
         if (t < 0.5f)
             return 2.0f * t * t;
         return -1.0f + (4.0f - 2.0f * t) * t;
+    case Easing::CUBIC_IN_OUT: {
+        float p = 2.0f * t - 2.0f;
+        if (t < 0.5f)
+            return 4.0f * t * t * t;
+        return 0.5f * p * p * p + 1.0f;
+    }
     }
     return t;
 }

--- a/include/game/IScenePresenter.h
+++ b/include/game/IScenePresenter.h
@@ -38,6 +38,11 @@ class IScenePresenter {
     virtual void set_courtroom_active(bool) {
     }
 
+    /// Set the local player's char_id and slide preference.
+    /// Used to force slide on our own echoed messages when the server strips the flag.
+    virtual void set_local_player(int /*char_id*/, bool /*slide_enabled*/) {
+    }
+
     struct ProfileEntry {
         const char* name;
         const std::atomic<int>* us;

--- a/include/render/RenderState.h
+++ b/include/render/RenderState.h
@@ -35,6 +35,13 @@ class RenderState {
     LayerGroup get_layer_group(int id);
 
     /**
+     * @brief Get a mutable pointer to a LayerGroup by its identifier.
+     * @param id Identifier of the requested group.
+     * @return Pointer to the LayerGroup, or nullptr if not found.
+     */
+    LayerGroup* get_mutable_layer_group(int id);
+
+    /**
      * @brief Get all layer groups.
      * @return A const copy of the internal map of LayerGroups keyed by id.
      */

--- a/include/render/TransformAnimator.h
+++ b/include/render/TransformAnimator.h
@@ -9,6 +9,7 @@ enum class Easing {
     QUAD_IN,
     QUAD_OUT,
     QUAD_IN_OUT,
+    CUBIC_IN_OUT,
 };
 
 struct TransformKeyframe {

--- a/plugins/ao/asset/AOAssetLibrary.cpp
+++ b/plugins/ao/asset/AOAssetLibrary.cpp
@@ -231,6 +231,77 @@ std::string AOAssetLibrary::design_value(const std::string& key) {
     return {};
 }
 
+// Read a value from background/{bg_name}/design.ini.
+// AO2 design.ini uses QSettings format where "/" is a section separator:
+//   "def/origin" → section "def", key "origin"
+//   "court:def/origin" → section "court:def", key "origin"
+static std::string bg_design_value(AssetLibrary& assets, const std::string& bg_name, const std::string& key) {
+    auto doc = assets.config("background/" + bg_name + "/design.ini");
+    if (!doc) {
+        Log::log_print(DEBUG, "bg_design_value: no design.ini for bg='%s'", bg_name.c_str());
+        return {};
+    }
+
+    // Split key on "/" into section + key (QSettings convention)
+    auto slash = key.find('/');
+    std::string section = slash != std::string::npos ? key.substr(0, slash) : "";
+    std::string subkey = slash != std::string::npos ? key.substr(slash + 1) : key;
+
+    // Dump available sections on first miss for debugging
+    auto it = doc->find(section);
+    if (it == doc->end()) {
+        std::string sections;
+        for (const auto& [s, _] : *doc)
+            sections += "'" + s + "' ";
+        Log::log_print(DEBUG, "bg_design_value: section '%s' not found in design.ini (have: %s)", section.c_str(),
+                       sections.c_str());
+        return {};
+    }
+    auto val = it->second.find(subkey);
+    if (val == it->second.end()) {
+        std::string keys;
+        for (const auto& [k, _] : it->second)
+            keys += "'" + k + "' ";
+        Log::log_print(DEBUG, "bg_design_value: key '%s' not found in section '%s' (have: %s)", subkey.c_str(),
+                       section.c_str(), keys.c_str());
+        return {};
+    }
+    return val->second;
+}
+
+std::optional<int> AOAssetLibrary::position_origin(const std::string& bg_name, const std::string& position) {
+    // Try "court:{position}/origin" first, then "{position}/origin"
+    std::string val = bg_design_value(assets, bg_name, "court:" + position + "/origin");
+    if (val.empty())
+        val = bg_design_value(assets, bg_name, position + "/origin");
+    if (val.empty())
+        return std::nullopt;
+    try {
+        return std::stoi(val);
+    }
+    catch (...) {
+        return std::nullopt;
+    }
+}
+
+static constexpr int DEFAULT_SLIDE_MS = 600;
+
+int AOAssetLibrary::slide_duration_ms(const std::string& bg_name, const std::string& from_pos,
+                                      const std::string& to_pos) {
+    // Try "court:{from}/slide_ms_{to}" first, then "{from}/slide_ms_{to}"
+    std::string val = bg_design_value(assets, bg_name, "court:" + from_pos + "/slide_ms_" + to_pos);
+    if (val.empty())
+        val = bg_design_value(assets, bg_name, from_pos + "/slide_ms_" + to_pos);
+    if (val.empty())
+        return DEFAULT_SLIDE_MS;
+    try {
+        return std::stoi(val);
+    }
+    catch (...) {
+        return DEFAULT_SLIDE_MS;
+    }
+}
+
 AOFontSpec AOAssetLibrary::message_font_spec() {
     ensure_configs();
     AOFontSpec spec;

--- a/plugins/ao/asset/AOAssetLibrary.h
+++ b/plugins/ao/asset/AOAssetLibrary.h
@@ -80,6 +80,14 @@ class AOAssetLibrary {
     /// Prefetch background images for a position (legacy + modern names).
     void prefetch_background(const std::string& name, const std::string& position, int priority = 3);
 
+    /// Pixel origin for a position on the background (from background/{name}/design.ini).
+    /// Used to determine slide direction. Returns nullopt if not configured.
+    std::optional<int> position_origin(const std::string& bg_name, const std::string& position);
+
+    /// Transition duration in ms between two positions (from background/{name}/design.ini).
+    /// Returns a default (600ms) if not configured.
+    int slide_duration_ms(const std::string& bg_name, const std::string& from_pos, const std::string& to_pos);
+
     // -------------------------------------------------------------------------
     // Theme / UI
     // -------------------------------------------------------------------------

--- a/plugins/ao/event/ICMessageEvent.cpp
+++ b/plugins/ao/event/ICMessageEvent.cpp
@@ -6,13 +6,13 @@ ICMessageEvent::ICMessageEvent(std::string character, std::string emote, std::st
                                std::string showname, std::string side, EmoteMod emote_mod, DeskMod desk_mod, bool flip,
                                int char_id, int text_color, int objection_mod, bool screenshake, bool realization,
                                bool additive, std::string frame_screenshake, std::string sfx_name, int sfx_delay,
-                               bool sfx_looping, std::string frame_sfx, bool immediate)
+                               bool sfx_looping, std::string frame_sfx, bool immediate, bool slide)
     : character(std::move(character)), emote(std::move(emote)), pre_emote(std::move(pre_emote)),
       message(std::move(message)), showname(std::move(showname)), side(std::move(side)), emote_mod(emote_mod),
       desk_mod(desk_mod), flip(flip), char_id(char_id), text_color(text_color), objection_mod(objection_mod),
       screenshake(screenshake), realization(realization), additive(additive),
       frame_screenshake(std::move(frame_screenshake)), sfx_name(std::move(sfx_name)), sfx_delay(sfx_delay),
-      sfx_looping(sfx_looping), frame_sfx(std::move(frame_sfx)), immediate(immediate) {
+      sfx_looping(sfx_looping), frame_sfx(std::move(frame_sfx)), immediate(immediate), slide(slide) {
 }
 
 std::string ICMessageEvent::to_string() const {

--- a/plugins/ao/event/ICMessageEvent.h
+++ b/plugins/ao/event/ICMessageEvent.h
@@ -51,7 +51,7 @@ class ICMessageEvent : public Event {
                    std::string showname, std::string side, EmoteMod emote_mod, DeskMod desk_mod, bool flip, int char_id,
                    int text_color, int objection_mod, bool screenshake, bool realization, bool additive,
                    std::string frame_screenshake, std::string sfx_name, int sfx_delay, bool sfx_looping,
-                   std::string frame_sfx, bool immediate = false);
+                   std::string frame_sfx, bool immediate = false, bool slide = false);
 
     std::string to_string() const override;
 
@@ -118,6 +118,9 @@ class ICMessageEvent : public Event {
     bool get_immediate() const {
         return immediate;
     }
+    bool get_slide() const {
+        return slide;
+    }
 
   private:
     std::string character;
@@ -141,4 +144,5 @@ class ICMessageEvent : public Event {
     bool sfx_looping;
     std::string frame_sfx;
     bool immediate;
+    bool slide;
 };

--- a/plugins/ao/game/AOBackground.cpp
+++ b/plugins/ao/game/AOBackground.cpp
@@ -40,6 +40,7 @@ void AOBackground::reload_if_needed(AOAssetLibrary& ao_assets) {
         return;
 
     ao_assets.prefetch_background(bg_name, pos);
+    ao_assets.engine_assets().prefetch_config("background/" + bg_name + "/design.ini");
 
     // Try loading the exact background without falling back to default.
     // If the real bg isn't available yet (HTTP pending), show the default

--- a/plugins/ao/game/AOCourtroomPresenter.cpp
+++ b/plugins/ao/game/AOCourtroomPresenter.cpp
@@ -1,44 +1,12 @@
 #include "ao/game/AOCourtroomPresenter.h"
 
-#include "ao/event/ICLogEvent.h"
 #include "ao/event/ICMessageEvent.h"
 #include "asset/MediaManager.h"
 #include "asset/MountManager.h"
-#include "asset/ShaderAsset.h"
 #include "event/BackgroundEvent.h"
 #include "event/EventManager.h"
-#include "event/PlaySFXEvent.h"
-#include "render/Layer.h"
 #include "render/RenderState.h"
 #include "utils/Log.h"
-
-#include <chrono>
-#include <cstring>
-
-/// Provides text color uniforms (u_text_r/g/b) to the text shader.
-class TextColorProvider : public ShaderUniformProvider {
-  public:
-    TextColorProvider(float r, float g, float b) : r_(r), g_(g), b_(b) {
-    }
-    std::unordered_map<std::string, UniformValue> get_uniforms() const override {
-        return {{"u_text_r", r_}, {"u_text_g", g_}, {"u_text_b", b_}};
-    }
-
-  private:
-    float r_, g_, b_;
-};
-
-class RainbowTextProvider : public ShaderUniformProvider {
-  public:
-    RainbowTextProvider(float time) : time_(time) {
-    }
-    std::unordered_map<std::string, UniformValue> get_uniforms() const override {
-        return {{"u_time", time_}};
-    }
-
-  private:
-    float time_;
-};
 
 AOCourtroomPresenter::AOCourtroomPresenter()
     : prof_events_(profiler_.add_section("Events")), prof_assets_(profiler_.add_section("Assets")),
@@ -77,106 +45,78 @@ void AOCourtroomPresenter::init() {
 }
 
 void AOCourtroomPresenter::play_message(const ICMessage& msg) {
-    // Stop all active effects before starting a new message
-    for_each_effect([](auto& e) { e.stop(); });
+    // Stop message effects (not slide — it has its own lifecycle)
+    for (auto& [name, effect] : message_effects_)
+        effect->stop();
 
-    active_ic_.emplace();
-    auto& ic = *active_ic_;
+    // Slide if the sender requested it (msg.slide) and the position changed.
+    // For our own messages, the flag may be force-enabled in the event drain
+    // (own_slide_enabled_) since the server can strip it from the echo.
+    std::string old_position = active_ic_ ? active_ic_->position : "";
+    std::string new_position = msg.side;
+    bool should_slide = false;
+
+    if (active_ic_ && msg.slide && !old_position.empty() && !new_position.empty() && old_position != new_position &&
+        msg.emote_mod != EmoteMod::ZOOM && msg.emote_mod != EmoteMod::PREANIM_ZOOM) {
+        int duration = ao_assets->slide_duration_ms(background.background(), old_position, new_position);
+        Log::log_print(DEBUG, "Slide check: bg='%s' %s→%s duration=%d", background.background().c_str(),
+                       old_position.c_str(), new_position.c_str(), duration);
+
+        if (duration > 0) {
+            departing_ic_ = std::move(active_ic_);
+            departing_ic_->bg_asset = background.bg_asset();
+            departing_ic_->desk_asset = background.desk_asset();
+
+            // Direction: if new origin > old origin, camera moves right (departing exits left).
+            // Default to LEFT if origins aren't configured.
+            auto from_origin = ao_assets->position_origin(background.background(), old_position);
+            auto to_origin = ao_assets->position_origin(background.background(), new_position);
+            auto dir = SlideEffect::Direction::LEFT;
+            if (from_origin && to_origin && *to_origin < *from_origin)
+                dir = SlideEffect::Direction::RIGHT;
+
+            slide_effect_.configure(dir, duration);
+            slide_effect_.trigger();
+            should_slide = true;
+            Log::log_print(DEBUG, "Slide: %s→%s (%dms, %s)", old_position.c_str(), new_position.c_str(), duration,
+                           dir == SlideEffect::Direction::LEFT ? "left" : "right");
+        }
+    }
+
+    if (!should_slide)
+        departing_ic_.reset();
 
     if (!msg.side.empty())
         background.set_position(msg.side);
 
-    if (msg.desk_mod == DeskMod::CHAT) {
-        // Default: desk shown for def/pro/wit, hidden for other positions
-        ic.show_desk = (msg.side == "def" || msg.side == "pro" || msg.side == "wit");
+    bool active = courtroom_active_.load(std::memory_order_acquire);
+    auto result = message_player_.play(msg, *ao_assets, textbox, active);
+
+    // During a slide, suppress the textbox until the slide finishes.
+    // Store the text data so it can be started after the slide completes.
+    if (should_slide && !msg.message.empty()) {
+        // Override any preanim blocking — slide takes priority and defers
+        // the textbox until the slide finishes instead.
+        result.ic.preanim_blocking = false;
+        result.ic.slide_pending = true;
+        result.ic.pending_showname = result.resolved_showname;
+        result.ic.pending_message = msg.message;
+        result.ic.pending_text_color = msg.text_color;
+        result.ic.pending_additive = msg.additive;
+        textbox.start_message("", "", 0, ao_assets->text_colors());
     }
-    else {
-        ic.show_desk = (msg.desk_mod == DeskMod::SHOW || msg.desk_mod == DeskMod::EMOTE_ONLY ||
-                        msg.desk_mod == DeskMod::EMOTE_ONLY_EX);
-    }
-    ic.flip = msg.flip;
 
-    // Prefetch character assets via HTTP
-    ao_assets->prefetch_character(msg.character, msg.emote, msg.pre_emote, 2);
+    active_ic_.emplace(std::move(result.ic));
 
-    // Always load the character sheet so char.ini is promoted from the HTTP
-    // raw cache into the asset cache (survives release_all_http eviction).
-    auto sheet = ao_assets->character_sheet(msg.character);
-
-    // Resolve showname: prefer the one from the message, fall back to char.ini
-    std::string showname = msg.showname;
-    if (showname.empty())
-        showname = sheet ? sheet->showname() : msg.character;
-
-    // Check if message text is blank (whitespace-only)
-    bool blank = true;
-    for (char c : msg.message) {
-        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
-            blank = false;
-            break;
+    // Fire scene effects by name
+    for (const auto& name : result.effects) {
+        for (auto& [ename, effect] : message_effects_) {
+            if (name == ename) {
+                effect->trigger();
+                break;
+            }
         }
     }
-
-    // Blank messages skip pre-anim and go straight to idle
-    if (msg.message.empty() || blank) {
-        textbox.start_message(showname, msg.message, msg.text_color, ao_assets->text_colors(), msg.additive);
-        emote_player.start(*ao_assets, msg.character, msg.emote, "", EmoteMod::IDLE);
-        emote_player.transition_to_idle();
-    }
-    else {
-        emote_player.start(*ao_assets, msg.character, msg.emote, msg.pre_emote, msg.emote_mod);
-
-        // Blocking preanim: defer textbox until preanim finishes
-        if (emote_player.state() == AOEmotePlayer::State::PREANIM && !msg.immediate) {
-            ic.preanim_blocking = true;
-            ic.pending_showname = showname;
-            ic.pending_message = msg.message;
-            ic.pending_text_color = msg.text_color;
-            ic.pending_additive = msg.additive;
-            // Keep textbox inactive during preanim
-            textbox.start_message("", "", 0, ao_assets->text_colors());
-        }
-        else {
-            // Immediate (no-int-pre) or no preanim: start text right away
-            textbox.start_message(showname, msg.message, msg.text_color, ao_assets->text_colors(), msg.additive);
-        }
-    }
-
-    if (msg.screenshake)
-        screenshake_.trigger();
-    if (msg.realization)
-        flash_.trigger();
-    if (msg.message.find("rainbow") != std::string::npos)
-        rainbow_.trigger();
-    if (msg.message.find("glass") != std::string::npos)
-        shatter_.trigger();
-    if (msg.message.find("cube") != std::string::npos)
-        cube_.trigger();
-
-    // Resolve SFX: use packet sfx_name, fall back to char.ini emote SFX
-    std::string sfx_name = msg.sfx_name;
-    bool sfx_looping = msg.sfx_looping;
-    if ((sfx_name.empty() || sfx_name == "0" || sfx_name == "1") && sheet) {
-        auto* emote_entry = sheet->find_emote(msg.emote);
-        if (emote_entry && !emote_entry->sfx_name.empty() && emote_entry->sfx_name != "0") {
-            sfx_name = emote_entry->sfx_name;
-            sfx_looping = emote_entry->sfx_looping;
-        }
-    }
-
-    // Load and play SFX
-    if (!sfx_name.empty() && sfx_name != "0" && sfx_name != "1") {
-        auto sfx_asset = ao_assets->sound_effect(sfx_name);
-        if (sfx_asset && courtroom_active_.load(std::memory_order_acquire)) {
-            EventManager::instance().get_channel<PlaySFXEvent>().publish(PlaySFXEvent(sfx_asset, sfx_looping, 1.0f));
-        }
-    }
-
-    // Initialize blip player for this character
-    blip_player_.start(*ao_assets, msg.character);
-    prev_chars_visible_ = 0;
-
-    EventManager::instance().get_channel<ICLogEvent>().publish(ICLogEvent(showname, msg.message, msg.text_color));
 }
 
 RenderState AOCourtroomPresenter::tick(uint64_t t) {
@@ -202,21 +142,28 @@ RenderState AOCourtroomPresenter::tick(uint64_t t) {
             // Area change: clear IC state so only the background shows
             textbox.start_message("", "", 0, ao_assets->text_colors());
             message_queue_.clear();
-            emote_player.stop();
             active_ic_.reset();
+            departing_ic_.reset();
             for_each_effect([](auto& e) { e.stop(); });
         }
 
         auto& ic_ch = EventManager::instance().get_channel<ICMessageEvent>();
         while (auto ev = ic_ch.get_event()) {
-            message_queue_.enqueue(ICMessage::from_event(*ev));
+            auto msg = ICMessage::from_event(*ev);
+            // Server may strip the slide field from the echo. If we have slide
+            // enabled and this is our own message, force it on.
+            if (!msg.slide && own_slide_enabled_ && msg.char_id == own_char_id_)
+                msg.slide = true;
+            message_queue_.enqueue(std::move(msg));
         }
 
         // Advance queue — dequeue next message when current one finishes.
-        // Don't advance during a blocking preanim (textbox is INACTIVE but message isn't done).
+        // Don't advance during a blocking preanim or slide (textbox is INACTIVE but message isn't done).
         bool preanim_blocking = active_ic_ && active_ic_->preanim_blocking;
-        bool text_done = !preanim_blocking && (textbox.text_state() == AOTextBox::TextState::DONE ||
-                                               textbox.text_state() == AOTextBox::TextState::INACTIVE);
+        bool slide_blocking = active_ic_ && active_ic_->slide_pending;
+        bool text_done = !preanim_blocking && !slide_blocking &&
+                         (textbox.text_state() == AOTextBox::TextState::DONE ||
+                          textbox.text_state() == AOTextBox::TextState::INACTIVE);
         message_queue_.tick(delta_ms, text_done);
 
         if (auto msg = message_queue_.next()) {
@@ -234,30 +181,38 @@ RenderState AOCourtroomPresenter::tick(uint64_t t) {
         }
 
         background.reload_if_needed(*ao_assets);
-        emote_player.retry_load(*ao_assets);
+        if (active_ic_)
+            active_ic_->emote_player.retry_load(*ao_assets);
+        if (departing_ic_)
+            departing_ic_->emote_player.retry_load(*ao_assets);
     }
 
     // ---- Animation ----
     {
         auto _ = profiler_.scope(prof_animation_);
 
-        auto prev_emote_state = emote_player.state();
-        emote_player.tick(delta_ms);
-
-        // Blocking preanim just finished → start the deferred textbox
-        if (active_ic_ && active_ic_->preanim_blocking && prev_emote_state == AOEmotePlayer::State::PREANIM &&
-            emote_player.state() == AOEmotePlayer::State::TALKING) {
+        if (active_ic_) {
             auto& ic = *active_ic_;
-            ic.preanim_blocking = false;
-            textbox.start_message(ic.pending_showname, ic.pending_message, ic.pending_text_color,
-                                  ao_assets->text_colors(), ic.pending_additive);
-            prev_chars_visible_ = 0;
+            auto prev_emote_state = ic.emote_player.state();
+            ic.emote_player.tick(delta_ms);
+
+            // Blocking preanim just finished → start the deferred textbox
+            if (ic.preanim_blocking && prev_emote_state == AOEmotePlayer::State::PREANIM &&
+                ic.emote_player.state() == AOEmotePlayer::State::TALKING) {
+                ic.preanim_blocking = false;
+                textbox.start_message(ic.pending_showname, ic.pending_message, ic.pending_text_color,
+                                      ao_assets->text_colors(), ic.pending_additive);
+                ic.prev_chars_visible = 0;
+            }
+
+            if (textbox.text_state() == AOTextBox::TextState::DONE &&
+                ic.emote_player.state() == AOEmotePlayer::State::TALKING) {
+                ic.emote_player.transition_to_idle();
+            }
         }
 
-        if (textbox.text_state() == AOTextBox::TextState::DONE &&
-            emote_player.state() == AOEmotePlayer::State::TALKING) {
-            emote_player.transition_to_idle();
-        }
+        if (departing_ic_)
+            departing_ic_->emote_player.tick(delta_ms);
     }
 
     // ---- Textbox ----
@@ -280,17 +235,41 @@ RenderState AOCourtroomPresenter::tick(uint64_t t) {
 
         music_player_.tick(active);
 
-        // Use text_advanced instead of is_talking(): the textbox may have
-        // already transitioned to DONE (e.g. single-char message) by the
-        // time we get here, but blips should still play for the new chars.
-        blip_player_.tick(*ao_assets, prev_chars_visible_, cur_chars, textbox.current_msg(), text_advanced, active);
-        prev_chars_visible_ = cur_chars;
+        if (active_ic_) {
+            auto& ic = *active_ic_;
+            // Use text_advanced instead of is_talking(): the textbox may have
+            // already transitioned to DONE (e.g. single-char message) by the
+            // time we get here, but blips should still play for the new chars.
+            ic.blip_player.tick(*ao_assets, ic.prev_chars_visible, cur_chars, textbox.current_msg(), text_advanced,
+                                active);
+            ic.prev_chars_visible = cur_chars;
+        }
     }
 
     // ---- Effects ----
     {
         auto _ = profiler_.scope(prof_effects_);
         for_each_effect([&](auto& e) { e.tick(delta_ms); });
+
+        // Clean up departing scene after the pan finishes. needs_departing_scene()
+        // is true during PRE_DELAY and SLIDING, false during POST_DELAY and INACTIVE.
+        if (departing_ic_ && !slide_effect_.needs_departing_scene()) {
+            departing_ic_.reset();
+            if (active_ic_ && active_ic_->slide_pending) {
+                active_ic_->slide_pending = false;
+                // If the emote is still in preanim, chain into preanim blocking
+                // instead of starting the textbox immediately.
+                if (active_ic_->emote_player.state() == AOEmotePlayer::State::PREANIM) {
+                    active_ic_->preanim_blocking = true;
+                }
+                else {
+                    textbox.start_message(active_ic_->pending_showname, active_ic_->pending_message,
+                                          active_ic_->pending_text_color, ao_assets->text_colors(),
+                                          active_ic_->pending_additive);
+                    active_ic_->prev_chars_visible = 0;
+                }
+            }
+        }
     }
 
     // ---- Hint AssetCache Evictions ----
@@ -312,80 +291,35 @@ RenderState AOCourtroomPresenter::tick(uint64_t t) {
     {
         auto _ = profiler_.scope(prof_compose_);
 
-        LayerGroup scene;
+        state = compositor_.compose(background, active_ic_ ? &*active_ic_ : nullptr,
+                                    departing_ic_ ? &*departing_ic_ : nullptr, textbox, scene_time_s_);
 
-        if (background.bg_asset()) {
-            scene.add_layer(0, Layer(background.bg_asset(), 0, 0));
-        }
-
-        if (emote_player.has_frame()) {
-            Layer char_layer(emote_player.asset(), emote_player.current_frame_index(), 5);
-            // Preserve sprite aspect ratio: lock height to viewport, scale width proportionally.
-            float sprite_aspect = (float)emote_player.asset()->width() / (float)emote_player.asset()->height();
-            float viewport_aspect = (float)BASE_W / (float)BASE_H;
-            char_layer.transform().scale({sprite_aspect / viewport_aspect, 1.0f});
-            scene.add_layer(5, std::move(char_layer));
-        }
-
-        if (background.desk_asset() && active_ic_ && active_ic_->show_desk) {
-            scene.add_layer(10, Layer(background.desk_asset(), 0, 10));
-        }
-
-        if (textbox.text_state() != AOTextBox::TextState::INACTIVE) {
-            // Chatbox background — positioned via transform at the chatbox rect
-            auto chatbox_bg = textbox.chatbox_background();
-            if (chatbox_bg && chatbox_bg->frame_count() > 0) {
-                const auto& rect = textbox.chatbox_position();
-                float ndc_w = (float)chatbox_bg->width() / BASE_W * 2.0f;
-                float ndc_h = (float)chatbox_bg->height() / BASE_H * 2.0f;
-                float ndc_x = ((float)rect.x / BASE_W) * 2.0f - 1.0f + ndc_w * 0.5f;
-                float ndc_y = 1.0f - ((float)rect.y / BASE_H) * 2.0f - ndc_h * 0.5f;
-
-                Layer bg_layer(chatbox_bg, 0, 20);
-                bg_layer.transform().scale({ndc_w * 0.5f, ndc_h * 0.5f});
-                bg_layer.transform().translate({ndc_x, ndc_y});
-                scene.add_layer(20, std::move(bg_layer));
-            }
-
-            // GPU text mesh
-            auto atlas = textbox.message_atlas();
-            auto mesh = textbox.message_mesh();
-            auto shader = textbox.text_shader();
-            if (atlas && mesh && mesh->index_count() > 0 && shader) {
-                // Per-vertex color is baked into the mesh by TextMeshBuilder.
-                // Rainbow characters use a sentinel vertex color; the shader
-                // needs u_time to animate them.
-                shader->set_uniform_provider(std::make_shared<RainbowTextProvider>(scene_time_s_));
-
-                Layer text_layer(atlas, 0, 21);
-                text_layer.set_mesh(mesh);
-                text_layer.set_shader(shader);
-                scene.add_layer(21, std::move(text_layer));
+        if (departing_ic_) {
+            // Slide: apply out/in transforms to separate layer groups
+            auto* departing_group = state.get_mutable_layer_group(0);
+            auto* arriving_group = state.get_mutable_layer_group(1);
+            if (departing_group && slide_effect_.is_active())
+                slide_effect_.apply_out(*departing_group);
+            if (arriving_group && slide_effect_.is_active())
+                slide_effect_.apply_in(*arriving_group);
+            // Apply message effects to the arriving group
+            if (arriving_group) {
+                for (auto& [name, effect] : message_effects_) {
+                    if (effect->is_active())
+                        effect->apply(*arriving_group);
+                }
             }
         }
-
-        // Nameplate: rendered once, positioned and scaled via GPU transform
-        auto nameplate = textbox.get_nameplate();
-        if (nameplate && textbox.text_state() != AOTextBox::TextState::INACTIVE) {
-            auto nl = textbox.nameplate_layout();
-
-            float ndc_w = (float)nameplate->width() * nl.scale / BASE_W * 2.0f;
-            float ndc_h = (float)nameplate->height() / (float)BASE_H * 2.0f;
-            float ndc_x = ((float)nl.x / BASE_W) * 2.0f - 1.0f + ndc_w * 0.5f;
-            float ndc_y = 1.0f - ((float)nl.y / BASE_H) * 2.0f - ndc_h * 0.5f;
-
-            Layer nameplate_layer(nameplate, 0, 25);
-            nameplate_layer.transform().scale({ndc_w * 0.5f, ndc_h * 0.5f});
-            nameplate_layer.transform().translate({ndc_x, ndc_y});
-            scene.add_layer(25, std::move(nameplate_layer));
+        else {
+            // Normal: apply all effects to the single layer group
+            auto* scene = state.get_mutable_layer_group(0);
+            if (scene) {
+                for_each_effect([&](auto& e) {
+                    if (e.is_active())
+                        e.apply(*scene);
+                });
+            }
         }
-
-        for_each_effect([&](auto& e) {
-            if (e.is_active())
-                e.apply(scene);
-        });
-
-        state.add_layer_group(0, scene);
     }
 
     return state;

--- a/plugins/ao/game/AOCourtroomPresenter.h
+++ b/plugins/ao/game/AOCourtroomPresenter.h
@@ -1,22 +1,24 @@
 #pragma once
 
 #include "AOBackground.h"
-#include "AOBlipPlayer.h"
-#include "AOEmotePlayer.h"
+#include "AOMessagePlayer.h"
 #include "AOMusicPlayer.h"
+#include "AOSceneCompositor.h"
 #include "AOTextBox.h"
+#include "ActiveICState.h"
 #include "ICMessageQueue.h"
 #include "ao/asset/AOAssetLibrary.h"
 #include "ao/game/effects/FlashEffect.h"
 #include "ao/game/effects/ScreenshakeEffect.h"
 #include "ao/game/effects/ShaderEffect.h"
+#include "ao/game/effects/SlideEffect.h"
 #include "game/IScenePresenter.h"
 #include "game/TickProfiler.h"
 
+#include <array>
 #include <atomic>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 class ISceneEffect;
@@ -31,6 +33,11 @@ class AOCourtroomPresenter : public IScenePresenter {
         courtroom_active_.store(active, std::memory_order_release);
     }
 
+    void set_local_player(int char_id, bool slide_enabled) override {
+        own_char_id_ = char_id;
+        own_slide_enabled_ = slide_enabled;
+    }
+
     std::vector<ProfileEntry> tick_profile() const override {
         return profiler_.entries();
     }
@@ -40,46 +47,48 @@ class AOCourtroomPresenter : public IScenePresenter {
 
     std::unique_ptr<AOAssetLibrary> ao_assets;
     AOBackground background;
-    AOEmotePlayer emote_player;
     AOTextBox textbox;
     ICMessageQueue message_queue_;
 
-    // Per-IC-message state. Present while a message is active, cleared when
-    // the message queue moves on.
-    struct ActiveICState {
-        bool flip = false;
-        bool show_desk = true;
-        bool preanim_blocking = false;
-        std::string pending_showname;
-        std::string pending_message;
-        int pending_text_color = 0;
-        bool pending_additive = false;
-    };
     std::optional<ActiveICState> active_ic_;
+    std::optional<ActiveICState> departing_ic_; // held during slide transitions
 
-    AOBlipPlayer blip_player_;
+    AOSceneCompositor compositor_;
+    AOMessagePlayer message_player_;
     AOMusicPlayer music_player_;
-    int prev_chars_visible_ = 0;
     std::atomic<bool> courtroom_active_{false};
+    std::atomic<int> own_char_id_{-1};
+    std::atomic<bool> own_slide_enabled_{false};
 
     int evict_timer_ms = 0;
-    int theme_retry_ms_ = 0;
     float scene_time_s_ = 0; // monotonic time for shader effects
 
-    // Scene effects
+    // Scene effects — keyed by name so AOMessagePlayer can trigger by string.
+    // Slide is separate because it has a different lifecycle (not stopped on new message).
     ScreenshakeEffect screenshake_;
     FlashEffect flash_{BASE_W, BASE_H};
     ShaderEffect rainbow_{"shaders/rainbow", 5.0f, 5};
     ShaderEffect shatter_{"shaders/shatter", 4.0f, 5};
     ShaderEffect cube_{"shaders/cube", 0, 5};
+    SlideEffect slide_effect_;
+
+    struct NamedEffect {
+        const char* name;
+        ISceneEffect* effect;
+    };
+    std::array<NamedEffect, 5> message_effects_ = {{
+        {"screenshake", &screenshake_},
+        {"flash", &flash_},
+        {"rainbow", &rainbow_},
+        {"shatter", &shatter_},
+        {"cube", &cube_},
+    }};
 
     template <typename F>
     void for_each_effect(F&& fn) {
-        fn(screenshake_);
-        fn(flash_);
-        fn(rainbow_);
-        fn(shatter_);
-        fn(cube_);
+        for (auto& [name, effect] : message_effects_)
+            fn(*effect);
+        fn(slide_effect_);
     }
 
     // Profiler sections (indices set in constructor)

--- a/plugins/ao/game/AOMessagePlayer.cpp
+++ b/plugins/ao/game/AOMessagePlayer.cpp
@@ -1,0 +1,107 @@
+#include "ao/game/AOMessagePlayer.h"
+
+#include "ao/event/ICLogEvent.h"
+#include "ao/game/AOTextBox.h"
+#include "event/EventManager.h"
+#include "event/PlaySFXEvent.h"
+
+AOMessagePlayer::Result AOMessagePlayer::play(const ICMessage& msg, AOAssetLibrary& ao_assets, AOTextBox& textbox,
+                                              bool active) {
+    Result result;
+    auto& ic = result.ic;
+    ic.position = msg.side;
+
+    // Desk visibility
+    if (msg.desk_mod == DeskMod::CHAT) {
+        ic.show_desk = (msg.side == "def" || msg.side == "pro" || msg.side == "wit");
+    }
+    else {
+        ic.show_desk = (msg.desk_mod == DeskMod::SHOW || msg.desk_mod == DeskMod::EMOTE_ONLY ||
+                        msg.desk_mod == DeskMod::EMOTE_ONLY_EX);
+    }
+    ic.flip = msg.flip;
+
+    // Prefetch character assets via HTTP
+    ao_assets.prefetch_character(msg.character, msg.emote, msg.pre_emote, 2);
+
+    // Load the character sheet so char.ini is promoted from the HTTP raw cache
+    // into the asset cache (survives release_all_http eviction).
+    auto sheet = ao_assets.character_sheet(msg.character);
+
+    // Resolve showname: prefer the one from the message, fall back to char.ini
+    std::string showname = msg.showname;
+    if (showname.empty())
+        showname = sheet ? sheet->showname() : msg.character;
+    result.resolved_showname = showname;
+
+    // Check if message text is blank (whitespace-only)
+    bool blank = true;
+    for (char c : msg.message) {
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+            blank = false;
+            break;
+        }
+    }
+
+    // Start emote + textbox
+    if (msg.message.empty() || blank) {
+        textbox.start_message(showname, msg.message, msg.text_color, ao_assets.text_colors(), msg.additive);
+        ic.emote_player.start(ao_assets, msg.character, msg.emote, "", EmoteMod::IDLE);
+        ic.emote_player.transition_to_idle();
+    }
+    else {
+        ic.emote_player.start(ao_assets, msg.character, msg.emote, msg.pre_emote, msg.emote_mod);
+
+        // Blocking preanim: defer textbox until preanim finishes
+        if (ic.emote_player.state() == AOEmotePlayer::State::PREANIM && !msg.immediate) {
+            ic.preanim_blocking = true;
+            ic.pending_showname = showname;
+            ic.pending_message = msg.message;
+            ic.pending_text_color = msg.text_color;
+            ic.pending_additive = msg.additive;
+            textbox.start_message("", "", 0, ao_assets.text_colors());
+        }
+        else {
+            textbox.start_message(showname, msg.message, msg.text_color, ao_assets.text_colors(), msg.additive);
+        }
+    }
+
+    // Effect triggers (names match presenter's NamedEffect keys)
+    if (msg.screenshake)
+        result.effects.push_back("screenshake");
+    if (msg.realization)
+        result.effects.push_back("flash");
+    if (msg.message.find("rainbow") != std::string::npos)
+        result.effects.push_back("rainbow");
+    if (msg.message.find("glass") != std::string::npos)
+        result.effects.push_back("shatter");
+    if (msg.message.find("cube") != std::string::npos)
+        result.effects.push_back("cube");
+
+    // Resolve SFX: use packet sfx_name, fall back to char.ini emote SFX
+    std::string sfx_name = msg.sfx_name;
+    bool sfx_looping = msg.sfx_looping;
+    if ((sfx_name.empty() || sfx_name == "0" || sfx_name == "1") && sheet) {
+        auto* emote_entry = sheet->find_emote(msg.emote);
+        if (emote_entry && !emote_entry->sfx_name.empty() && emote_entry->sfx_name != "0") {
+            sfx_name = emote_entry->sfx_name;
+            sfx_looping = emote_entry->sfx_looping;
+        }
+    }
+
+    if (!sfx_name.empty() && sfx_name != "0" && sfx_name != "1") {
+        auto sfx_asset = ao_assets.sound_effect(sfx_name);
+        if (sfx_asset && active) {
+            EventManager::instance().get_channel<PlaySFXEvent>().publish(PlaySFXEvent(sfx_asset, sfx_looping, 1.0f));
+        }
+    }
+
+    // Blip player
+    ic.blip_player.start(ao_assets, msg.character);
+    ic.prev_chars_visible = 0;
+
+    // IC log
+    EventManager::instance().get_channel<ICLogEvent>().publish(ICLogEvent(showname, msg.message, msg.text_color));
+
+    return result;
+}

--- a/plugins/ao/game/AOMessagePlayer.h
+++ b/plugins/ao/game/AOMessagePlayer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "ActiveICState.h"
+#include "ICMessageQueue.h"
+
+#include <string>
+#include <vector>
+
+class AOAssetLibrary;
+class AOTextBox;
+
+/// Initializes an ActiveICState from an incoming ICMessage.
+///
+/// Handles character sheet lookup, showname resolution, emote start,
+/// preanim blocking, SFX playback, blip setup, and IC log publishing.
+/// Returns the initialized state plus a list of effect names to trigger.
+class AOMessagePlayer {
+  public:
+    struct Result {
+        ActiveICState ic;
+        std::vector<std::string> effects; // names matching presenter's NamedEffect keys
+        std::string resolved_showname;    // showname after char.ini fallback
+    };
+
+    /// Initialize a new IC state from a message.
+    Result play(const ICMessage& msg, AOAssetLibrary& ao_assets, AOTextBox& textbox, bool active);
+};

--- a/plugins/ao/game/AOSceneCompositor.cpp
+++ b/plugins/ao/game/AOSceneCompositor.cpp
@@ -1,0 +1,126 @@
+#include "ao/game/AOSceneCompositor.h"
+
+#include "ao/game/AOBackground.h"
+#include "ao/game/AOTextBox.h"
+#include "ao/game/ActiveICState.h"
+#include "asset/ShaderAsset.h"
+#include "render/Layer.h"
+#include "render/RenderState.h"
+
+static constexpr int BASE_W = 256;
+static constexpr int BASE_H = 192;
+
+class RainbowTextProvider : public ShaderUniformProvider {
+  public:
+    RainbowTextProvider(float time) : time_(time) {
+    }
+    std::unordered_map<std::string, UniformValue> get_uniforms() const override {
+        return {{"u_time", time_}};
+    }
+
+  private:
+    float time_;
+};
+
+static void add_character_layer(LayerGroup& scene, const ActiveICState& ic, int z_index, int base_w, int base_h) {
+    if (!ic.emote_player.has_frame())
+        return;
+    Layer char_layer(ic.emote_player.asset(), ic.emote_player.current_frame_index(), z_index);
+    float sprite_aspect = (float)ic.emote_player.asset()->width() / (float)ic.emote_player.asset()->height();
+    float viewport_aspect = (float)base_w / (float)base_h;
+    char_layer.transform().scale({sprite_aspect / viewport_aspect, 1.0f});
+    scene.add_layer(z_index, std::move(char_layer));
+}
+
+// Add background + character + desk to a group using the shared background.
+static void compose_scene_group(LayerGroup& group, const AOBackground& background, const ActiveICState* ic) {
+    if (background.bg_asset())
+        group.add_layer(0, Layer(background.bg_asset(), 0, 0));
+    if (ic)
+        add_character_layer(group, *ic, 5, BASE_W, BASE_H);
+    if (background.desk_asset() && ic && ic->show_desk)
+        group.add_layer(10, Layer(background.desk_asset(), 0, 10));
+}
+
+// Add background + character + desk to a group using IC-snapshotted assets
+// (for the departing scene during a slide, where the shared background has
+// already changed to the new position).
+static void compose_departing_group(LayerGroup& group, const ActiveICState& ic) {
+    if (ic.bg_asset)
+        group.add_layer(0, Layer(ic.bg_asset, 0, 0));
+    add_character_layer(group, ic, 5, BASE_W, BASE_H);
+    if (ic.desk_asset && ic.show_desk)
+        group.add_layer(10, Layer(ic.desk_asset, 0, 10));
+}
+
+// Add textbox layers (chatbox bg, text mesh, nameplate) to a group.
+static void compose_textbox(LayerGroup& group, AOTextBox& textbox, float scene_time_s) {
+    if (textbox.text_state() == AOTextBox::TextState::INACTIVE)
+        return;
+
+    auto chatbox_bg = textbox.chatbox_background();
+    if (chatbox_bg && chatbox_bg->frame_count() > 0) {
+        const auto& rect = textbox.chatbox_position();
+        float ndc_w = (float)chatbox_bg->width() / BASE_W * 2.0f;
+        float ndc_h = (float)chatbox_bg->height() / BASE_H * 2.0f;
+        float ndc_x = ((float)rect.x / BASE_W) * 2.0f - 1.0f + ndc_w * 0.5f;
+        float ndc_y = 1.0f - ((float)rect.y / BASE_H) * 2.0f - ndc_h * 0.5f;
+
+        Layer bg_layer(chatbox_bg, 0, 20);
+        bg_layer.transform().scale({ndc_w * 0.5f, ndc_h * 0.5f});
+        bg_layer.transform().translate({ndc_x, ndc_y});
+        group.add_layer(20, std::move(bg_layer));
+    }
+
+    auto atlas = textbox.message_atlas();
+    auto mesh = textbox.message_mesh();
+    auto shader = textbox.text_shader();
+    if (atlas && mesh && mesh->index_count() > 0 && shader) {
+        shader->set_uniform_provider(std::make_shared<RainbowTextProvider>(scene_time_s));
+        Layer text_layer(atlas, 0, 21);
+        text_layer.set_mesh(mesh);
+        text_layer.set_shader(shader);
+        group.add_layer(21, std::move(text_layer));
+    }
+
+    auto nameplate = textbox.get_nameplate();
+    if (nameplate) {
+        auto nl = textbox.nameplate_layout();
+        float ndc_w = (float)nameplate->width() * nl.scale / BASE_W * 2.0f;
+        float ndc_h = (float)nameplate->height() / (float)BASE_H * 2.0f;
+        float ndc_x = ((float)nl.x / BASE_W) * 2.0f - 1.0f + ndc_w * 0.5f;
+        float ndc_y = 1.0f - ((float)nl.y / BASE_H) * 2.0f - ndc_h * 0.5f;
+
+        Layer nameplate_layer(nameplate, 0, 25);
+        nameplate_layer.transform().scale({ndc_w * 0.5f, ndc_h * 0.5f});
+        nameplate_layer.transform().translate({ndc_x, ndc_y});
+        group.add_layer(25, std::move(nameplate_layer));
+    }
+}
+
+RenderState AOSceneCompositor::compose(const AOBackground& background, const ActiveICState* active_ic,
+                                       const ActiveICState* departing_ic, AOTextBox& textbox, float scene_time_s) {
+    RenderState state;
+
+    if (departing_ic) {
+        // Slide transition: two separate layer groups for independent transforms.
+        // Group 0 = departing (snapshotted bg), Group 1 = arriving (live bg).
+        LayerGroup departing_group;
+        compose_departing_group(departing_group, *departing_ic);
+        state.add_layer_group(0, departing_group);
+
+        LayerGroup arriving_group;
+        compose_scene_group(arriving_group, background, active_ic);
+        compose_textbox(arriving_group, textbox, scene_time_s);
+        state.add_layer_group(1, arriving_group);
+    }
+    else {
+        // Normal: single layer group.
+        LayerGroup scene;
+        compose_scene_group(scene, background, active_ic);
+        compose_textbox(scene, textbox, scene_time_s);
+        state.add_layer_group(0, scene);
+    }
+
+    return state;
+}

--- a/plugins/ao/game/AOSceneCompositor.h
+++ b/plugins/ao/game/AOSceneCompositor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class AOBackground;
+struct ActiveICState;
+class AOTextBox;
+class RenderState;
+
+/// Composes the courtroom scene into a RenderState each frame.
+///
+/// Reads from the presenter's components (background, IC states, textbox)
+/// and produces a layered render output. Separated from the presenter to
+/// keep tick() focused on state advancement.
+class AOSceneCompositor {
+  public:
+    RenderState compose(const AOBackground& background, const ActiveICState* active_ic,
+                        const ActiveICState* departing_ic, AOTextBox& textbox, float scene_time_s);
+};

--- a/plugins/ao/game/ActiveICState.h
+++ b/plugins/ao/game/ActiveICState.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "AOBlipPlayer.h"
+#include "AOEmotePlayer.h"
+#include "asset/ImageAsset.h"
+
+#include <memory>
+#include <string>
+
+/// Per-IC-message state. Present while a message is active, cleared when
+/// the message queue moves on. Each IC state owns its own emote and blip
+/// players so that during slide transitions, the departing character's
+/// animation can keep running alongside the arriving character's.
+struct ActiveICState {
+    bool flip = false;
+    bool show_desk = true;
+    bool preanim_blocking = false;
+    bool slide_pending = false; // textbox deferred until slide finishes
+    std::string pending_showname;
+    std::string pending_message;
+    int pending_text_color = 0;
+    bool pending_additive = false;
+
+    AOEmotePlayer emote_player;
+    AOBlipPlayer blip_player;
+    int prev_chars_visible = 0;
+    std::string position;
+
+    // Snapshot of the background/desk for this position, so the departing
+    // IC state keeps its own background during slide transitions.
+    std::shared_ptr<ImageAsset> bg_asset;
+    std::shared_ptr<ImageAsset> desk_asset;
+};

--- a/plugins/ao/game/ICMessageQueue.h
+++ b/plugins/ao/game/ICMessageQueue.h
@@ -29,13 +29,15 @@ struct ICMessage {
     bool sfx_looping = false;
     std::string frame_sfx;
     bool immediate = false;
+    bool slide = false;
 
     static ICMessage from_event(const ICMessageEvent& ev) {
         return {ev.get_character(),   ev.get_emote(),       ev.get_pre_emote(),     ev.get_message(),
                 ev.get_showname(),    ev.get_side(),        ev.get_emote_mod(),     ev.get_desk_mod(),
                 ev.get_flip(),        ev.get_char_id(),     ev.get_text_color(),    ev.get_screenshake(),
                 ev.get_realization(), ev.get_additive(),    ev.get_objection_mod(), ev.get_sfx_name(),
-                ev.get_sfx_delay(),   ev.get_sfx_looping(), ev.get_frame_sfx(),     ev.get_immediate()};
+                ev.get_sfx_delay(),   ev.get_sfx_looping(), ev.get_frame_sfx(),     ev.get_immediate(),
+                ev.get_slide()};
     }
 
     bool is_objection() const {

--- a/plugins/ao/game/effects/ISceneEffect.h
+++ b/plugins/ao/game/effects/ISceneEffect.h
@@ -20,6 +20,8 @@ class ISceneEffect {
     virtual void tick(int delta_ms) = 0;
 
     /// Apply the effect's current state to the scene.
+    /// Some effects (e.g. SlideEffect) use specialized apply methods for
+    /// multi-group scenes and implement this as a no-op.
     virtual void apply(LayerGroup& scene) = 0;
 
     /// Whether the effect is currently active (playing or needs to apply).

--- a/plugins/ao/game/effects/SlideEffect.cpp
+++ b/plugins/ao/game/effects/SlideEffect.cpp
@@ -1,0 +1,100 @@
+#include "ao/game/effects/SlideEffect.h"
+
+#include "render/Layer.h"
+
+void SlideEffect::configure(Direction direction, int duration_ms) {
+    // Departing scene exits in the given direction; arriving enters from the opposite.
+    float exit_x = (direction == Direction::LEFT) ? -2.0f : 2.0f;
+    float enter_x = -exit_x;
+
+    out_anim_.clear_keyframes();
+    out_anim_.set_easing(Easing::CUBIC_IN_OUT);
+    out_anim_.set_looping(false);
+    out_anim_.add_keyframe({0, {0, 0}, {1, 1}, 0});
+    out_anim_.add_keyframe({duration_ms, {exit_x, 0}, {1, 1}, 0});
+
+    in_anim_.clear_keyframes();
+    in_anim_.set_easing(Easing::CUBIC_IN_OUT);
+    in_anim_.set_looping(false);
+    in_anim_.add_keyframe({0, {enter_x, 0}, {1, 1}, 0});
+    in_anim_.add_keyframe({duration_ms, {0, 0}, {1, 1}, 0});
+
+    enter_x_ = enter_x;
+}
+
+void SlideEffect::trigger() {
+    phase_ = Phase::PRE_DELAY;
+    delay_remaining_ms_ = BOOKEND_DELAY_MS;
+}
+
+void SlideEffect::stop() {
+    phase_ = Phase::INACTIVE;
+    out_anim_.stop();
+    out_anim_.reset();
+    in_anim_.stop();
+    in_anim_.reset();
+}
+
+void SlideEffect::tick(int delta_ms) {
+    switch (phase_) {
+    case Phase::INACTIVE:
+        return;
+
+    case Phase::PRE_DELAY:
+        delay_remaining_ms_ -= delta_ms;
+        if (delay_remaining_ms_ <= 0) {
+            phase_ = Phase::SLIDING;
+            out_anim_.play();
+            in_anim_.play();
+            // Apply leftover time from this frame to the animators
+            int leftover = -delay_remaining_ms_;
+            out_anim_.tick(leftover);
+            in_anim_.tick(leftover);
+        }
+        break;
+
+    case Phase::SLIDING:
+        out_anim_.tick(delta_ms);
+        in_anim_.tick(delta_ms);
+        if (out_anim_.is_finished()) {
+            phase_ = Phase::POST_DELAY;
+            delay_remaining_ms_ = BOOKEND_DELAY_MS;
+        }
+        break;
+
+    case Phase::POST_DELAY:
+        delay_remaining_ms_ -= delta_ms;
+        if (delay_remaining_ms_ <= 0) {
+            phase_ = Phase::INACTIVE;
+        }
+        break;
+    }
+}
+
+void SlideEffect::apply(LayerGroup&) {
+    // No-op — use apply_out/apply_in on separate layer groups.
+}
+
+void SlideEffect::apply_out(LayerGroup& scene) {
+    if (phase_ == Phase::SLIDING)
+        out_anim_.apply(scene.transform());
+    // During pre-delay, departing scene stays at origin (no transform needed)
+}
+
+void SlideEffect::apply_in(LayerGroup& scene) {
+    if (phase_ == Phase::SLIDING) {
+        in_anim_.apply(scene.transform());
+    }
+    else if (phase_ == Phase::PRE_DELAY) {
+        // Arriving scene is off-screen during pre-delay
+        scene.transform().translate({enter_x_, 0});
+    }
+}
+
+bool SlideEffect::needs_departing_scene() const {
+    return phase_ == Phase::PRE_DELAY || phase_ == Phase::SLIDING;
+}
+
+bool SlideEffect::is_active() const {
+    return phase_ != Phase::INACTIVE;
+}

--- a/plugins/ao/game/effects/SlideEffect.h
+++ b/plugins/ao/game/effects/SlideEffect.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "ao/game/effects/ISceneEffect.h"
+#include "render/TransformAnimator.h"
+
+/// Horizontal pan transition between courtroom positions.
+///
+/// Drives two animations: the departing scene slides out while the
+/// arriving scene slides in. Both are synchronized with the same
+/// phase timing (pre-delay, slide, post-delay).
+class SlideEffect : public ISceneEffect {
+  public:
+    enum class Direction { LEFT, RIGHT };
+
+    /// Configure a slide transition.
+    /// @param direction Which way the departing scene exits.
+    /// @param duration_ms Pan duration in milliseconds.
+    void configure(Direction direction, int duration_ms);
+
+    void trigger() override;
+    void stop() override;
+    void tick(int delta_ms) override;
+    bool is_active() const override;
+
+    /// Apply is a no-op — use apply_out/apply_in on separate layer groups.
+    void apply(LayerGroup& scene) override;
+
+    /// True during PRE_DELAY and SLIDING — the departing scene should be visible.
+    bool needs_departing_scene() const;
+
+    /// Apply the departing (slide-out) transform.
+    void apply_out(LayerGroup& scene);
+
+    /// Apply the arriving (slide-in) transform.
+    void apply_in(LayerGroup& scene);
+
+  private:
+    TransformAnimator out_anim_;
+    TransformAnimator in_anim_;
+    float enter_x_ = 2.0f; // arriving scene's off-screen start position
+
+    enum class Phase { INACTIVE, PRE_DELAY, SLIDING, POST_DELAY };
+    Phase phase_ = Phase::INACTIVE;
+    int delay_remaining_ms_ = 0;
+
+    static constexpr int BOOKEND_DELAY_MS = 300;
+};

--- a/plugins/net/ao/PacketBehavior.cpp
+++ b/plugins/net/ao/PacketBehavior.cpp
@@ -172,7 +172,7 @@ void AOPacketMS::handle(AOClient& cli) {
     EventManager::instance().get_channel<ICMessageEvent>().publish(ICMessageEvent(
         character, emote, pre_emote, message, showname, side, static_cast<EmoteMod>(emote_mod),
         static_cast<DeskMod>(desk_mod), flip, char_id, text_color, objection_mod, screenshake, realization, additive,
-        frame_screenshake, sfx_name, sfx_delay, sfx_looping, frame_sfx, immediate));
+        frame_screenshake, sfx_name, sfx_delay, sfx_looping, frame_sfx, immediate, slide));
 }
 
 void AOPacketBN::handle(AOClient& cli) {

--- a/plugins/net/ao/PacketTypes.cpp
+++ b/plugins/net/ao/PacketTypes.cpp
@@ -272,7 +272,9 @@ AOPacketMS::AOPacketMS(const ICMessageData& d)
            ao_encode(d.showname), std::to_string(d.other_charid), ao_encode(d.self_offset), std::to_string(d.immediate),
            // 19-25: 2.8 extensions
            std::to_string(d.looping_sfx), std::to_string(d.screenshake), ao_encode(d.frame_screenshake),
-           ao_encode(d.frame_realization), ao_encode(d.frame_sfx), std::to_string(d.additive), ao_encode(d.effects)}) {
+           ao_encode(d.frame_realization), ao_encode(d.frame_sfx), std::to_string(d.additive), ao_encode(d.effects),
+           // 26-27: blipname + slide (client→server only; pair fields are server-added)
+           ao_encode(d.blipname), d.slide}) {
 }
 
 AOPacketMS::AOPacketMS(const std::vector<std::string>& fields) : AOPacket("MS", fields) {
@@ -315,6 +317,9 @@ AOPacketMS::AOPacketMS(const std::vector<std::string>& fields) : AOPacket("MS", 
             frame_sfx = ao_decode(fields[27]);
         if (fields.size() > 28)
             additive = fields[28] == "1";
+        // fields[29] = effects, fields[30] = blipname (not yet used)
+        if (fields.size() > 31)
+            slide = fields[31] == "1";
 
         // Legacy emote_mod remapping
         if (emote_mod == 4)

--- a/plugins/net/ao/PacketTypes.h
+++ b/plugins/net/ao/PacketTypes.h
@@ -264,6 +264,7 @@ class AOPacketMS : public AOPacket {
     bool sfx_looping = false;
     std::string frame_sfx;
     bool immediate = false;
+    bool slide = false;
 
     static PacketRegistrar registrar;
     static constexpr int MIN_FIELDS = 15;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,10 @@ set(TEST_SOURCES
     ao/game/test_AOBackground.cpp
     ao/game/test_ICMessageQueue.cpp
     ao/game/test_SceneEffects.cpp
+    ao/game/test_SlideEffect.cpp
+    ao/game/test_AOMessagePlayer.cpp
+    ao/game/test_AOSceneCompositor.cpp
+    ao/game/test_AOCourtroomPresenter.cpp
     asset/test_AssetLibrary.cpp
     asset/test_AssetCache.cpp
     asset/test_ApngDecoder.cpp

--- a/tests/ao/asset/test_AOAssetLibrary.cpp
+++ b/tests/ao/asset/test_AOAssetLibrary.cpp
@@ -1,6 +1,7 @@
 #include "ao/asset/AOAssetLibrary.h"
 
 #include "asset/AssetLibrary.h"
+#include "asset/Mount.h"
 #include "asset/MountManager.h"
 
 #include <gtest/gtest.h>
@@ -152,4 +153,63 @@ TEST_F(AOAssetLibraryTest, TextColorsIndex4IsBlueAndNotTalking) {
 TEST_F(AOAssetLibraryTest, FindFontReturnsNulloptWithNoMounts) {
     auto result = ao_assets.find_font("arial");
     EXPECT_FALSE(result.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Position origin and slide duration
+// ---------------------------------------------------------------------------
+
+namespace {
+
+class InMemoryMount : public Mount {
+  public:
+    InMemoryMount() : Mount("memory://") {
+    }
+    void add(const std::string& path, const std::string& content) {
+        files_[path] = {content.begin(), content.end()};
+    }
+    void load() override {
+    }
+    bool seek_file(const std::string& path) const override {
+        return files_.count(path) > 0;
+    }
+    std::vector<uint8_t> fetch_data(const std::string& path) override {
+        auto it = files_.find(path);
+        return it != files_.end() ? it->second : std::vector<uint8_t>{};
+    }
+
+  protected:
+    void load_cache() override {
+    }
+    void save_cache() override {
+    }
+
+  private:
+    std::unordered_map<std::string, std::vector<uint8_t>> files_;
+};
+
+} // namespace
+
+TEST(AOAssetLibraryPositionData, SlideDurationDefaultWithNoConfig) {
+    MountManager mounts;
+    AssetLibrary engine(mounts, 0);
+    AOAssetLibrary ao(engine);
+    // Returns a sensible default (600ms) when no design.ini exists
+    EXPECT_GT(ao.slide_duration_ms("gs4", "def", "wit"), 0);
+}
+
+TEST(AOAssetLibraryPositionData, SlideDurationParsed) {
+    MountManager mounts;
+    auto mount = std::make_unique<InMemoryMount>();
+    // QSettings INI format: "def/slide_ms_wit" becomes section [def], key slide_ms_wit
+    mount->add("background/gs4/design.ini", "[def]\nslide_ms_wit = 800\n[wit]\nslide_ms_def = 600\n");
+    mounts.add_mount(std::move(mount));
+
+    AssetLibrary engine(mounts, 0);
+    AOAssetLibrary ao(engine);
+
+    EXPECT_EQ(ao.slide_duration_ms("gs4", "def", "wit"), 800);
+    EXPECT_EQ(ao.slide_duration_ms("gs4", "wit", "def"), 600);
+    // def→pro not in config, but still returns default
+    EXPECT_GT(ao.slide_duration_ms("gs4", "def", "pro"), 0);
 }

--- a/tests/ao/game/test_AOCourtroomPresenter.cpp
+++ b/tests/ao/game/test_AOCourtroomPresenter.cpp
@@ -1,0 +1,251 @@
+#include "ao/game/AOCourtroomPresenter.h"
+
+#include "ao/event/ICLogEvent.h"
+#include "ao/event/ICMessageEvent.h"
+#include "event/BackgroundEvent.h"
+#include "event/EventManager.h"
+#include "render/RenderState.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+template <typename T>
+static void drain(EventChannel<T>& ch) {
+    while (ch.get_event()) {
+    }
+}
+
+static void drain_presenter_channels() {
+    auto& em = EventManager::instance();
+    drain(em.get_channel<ICMessageEvent>());
+    drain(em.get_channel<BackgroundEvent>());
+    drain(em.get_channel<ICLogEvent>());
+}
+
+class AOCourtroomPresenterTest : public ::testing::Test {
+  protected:
+    AOCourtroomPresenter presenter;
+
+    void SetUp() override {
+        drain_presenter_channels();
+        presenter.init();
+    }
+
+    void TearDown() override {
+        drain_presenter_channels();
+    }
+
+    // Publish an IC message event and tick once to process it
+    void send_ic(const std::string& character, const std::string& message, const std::string& side,
+                 EmoteMod mod = EmoteMod::IDLE, bool slide = false) {
+        EventManager::instance().get_channel<ICMessageEvent>().publish(
+            ICMessageEvent(character, "normal", "", message, character, side, mod, DeskMod::CHAT, false, 0, 0, 0, false,
+                           false, false, "", "", 0, false, "", false, slide));
+        presenter.tick(16);
+    }
+
+    void send_background(const std::string& bg, const std::string& pos = "") {
+        EventManager::instance().get_channel<BackgroundEvent>().publish(BackgroundEvent(bg, pos));
+        presenter.tick(16);
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Basic lifecycle
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, TickProducesRenderState) {
+    auto state = presenter.tick(16);
+    auto& groups = state.get_layer_groups();
+    EXPECT_GE(groups.size(), 1u);
+}
+
+TEST_F(AOCourtroomPresenterTest, TickProfileHasSections) {
+    auto profile = presenter.tick_profile();
+    EXPECT_FALSE(profile.empty());
+}
+
+// ---------------------------------------------------------------------------
+// IC message handling
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, ICMessagePublishesICLog) {
+    auto& log_ch = EventManager::instance().get_channel<ICLogEvent>();
+    drain(log_ch);
+
+    send_ic("Phoenix", "Hello!", "def");
+
+    auto ev = log_ch.get_event();
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_EQ(ev->get_message(), "Hello!");
+}
+
+TEST_F(AOCourtroomPresenterTest, BlankMessageDoesNotCrash) {
+    EXPECT_NO_FATAL_FAILURE(send_ic("Phoenix", "", "def"));
+}
+
+TEST_F(AOCourtroomPresenterTest, WhitespaceOnlyMessageDoesNotCrash) {
+    EXPECT_NO_FATAL_FAILURE(send_ic("Phoenix", "   ", "def"));
+}
+
+// ---------------------------------------------------------------------------
+// Background / area changes
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, BackgroundEventClearsICState) {
+    send_ic("Phoenix", "Hello!", "def");
+    send_background("gs4", "wit");
+
+    // After area change, tick should produce a valid state with no character
+    auto state = presenter.tick(16);
+    EXPECT_GE(state.get_layer_groups().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Position changes without slide
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, PositionChangeWithoutSlideProducesSingleGroup) {
+    send_ic("Phoenix", "Hello", "def");
+    send_ic("Edgeworth", "Objection", "pro"); // no slide flag
+
+    auto state = presenter.tick(16);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Slide transitions
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, SlideProducesTwoGroups) {
+    // Both messages in the same tick — queue processes first immediately,
+    // second is queued. Tick enough for first to finish, then second triggers slide.
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Phoenix", "normal", "", "Hi", "Phoenix", "def", EmoteMod::IDLE, DeskMod::CHAT, false, 0, 0, 0,
+                       false, false, false, "", "", 0, false, "", false, false));
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Edgeworth", "normal", "", "Objection", "Edgeworth", "pro", EmoteMod::IDLE, DeskMod::CHAT, false,
+                       1, 0, 0, false, false, false, "", "", 0, false, "", false, true));
+
+    // First tick: both enqueued, first dequeued and played
+    presenter.tick(16);
+
+    // Tick until first message finishes and second is dequeued with slide
+    bool found_two_groups = false;
+    for (int i = 0; i < 100; i++) {
+        auto state = presenter.tick(16);
+        if (state.get_layer_groups().size() == 2u) {
+            found_two_groups = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_two_groups);
+}
+
+TEST_F(AOCourtroomPresenterTest, SlideBlocksQueueAdvancement) {
+    send_ic("Phoenix", "Hello", "def");
+
+    // Send slide + a queued message
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Edgeworth", "normal", "", "Objection", "Edgeworth", "pro", EmoteMod::IDLE, DeskMod::CHAT, false,
+                       1, 0, 0, false, false, false, "", "", 0, false, "", false, true));
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Judge", "normal", "", "Order!", "Judge", "jud", EmoteMod::IDLE, DeskMod::CHAT, false, 2, 0, 0,
+                       false, false, false, "", "", 0, false, "", false, false));
+    presenter.tick(16);
+
+    // Tick a few frames — slide should still be active, Judge's message queued
+    for (int i = 0; i < 10; i++)
+        presenter.tick(16);
+
+    // After enough time for slide to finish (300+600+300=1200ms), queue should advance
+    for (int i = 0; i < 100; i++)
+        presenter.tick(16);
+
+    // Should eventually settle to single group (slide done)
+    auto state = presenter.tick(16);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u);
+}
+
+TEST_F(AOCourtroomPresenterTest, SlideWithZoomEmoteDoesNotSlide) {
+    send_ic("Phoenix", "Hello", "def");
+    send_ic("Edgeworth", "Objection", "pro", EmoteMod::ZOOM, true);
+
+    auto state = presenter.tick(16);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u); // no slide despite flag
+}
+
+TEST_F(AOCourtroomPresenterTest, SlideSamePositionDoesNotSlide) {
+    send_ic("Phoenix", "Hello", "def");
+    send_ic("Phoenix", "More text", "def", EmoteMod::IDLE, true);
+
+    auto state = presenter.tick(16);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Local player slide
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, LocalPlayerSlideForced) {
+    presenter.set_local_player(42, true);
+
+    // Both messages together — second is ours without slide flag but local slide enabled
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Phoenix", "normal", "", "Hi", "Phoenix", "def", EmoteMod::IDLE, DeskMod::CHAT, false, 42, 0, 0,
+                       false, false, false, "", "", 0, false, "", false, false));
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Phoenix", "normal", "", "Objection", "Phoenix", "pro", EmoteMod::IDLE, DeskMod::CHAT, false, 42,
+                       0, 0, false, false, false, "", "", 0, false, "", false, false));
+    presenter.tick(16);
+
+    bool found_two_groups = false;
+    for (int i = 0; i < 100; i++) {
+        auto state = presenter.tick(16);
+        if (state.get_layer_groups().size() == 2u) {
+            found_two_groups = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_two_groups);
+}
+
+TEST_F(AOCourtroomPresenterTest, LocalPlayerSlideNotForcedForOthers) {
+    presenter.set_local_player(42, true);
+    send_ic("Phoenix", "Hello", "def");
+
+    // Someone else's message without slide flag
+    EventManager::instance().get_channel<ICMessageEvent>().publish(
+        ICMessageEvent("Edgeworth", "normal", "", "Objection", "Edgeworth", "pro", EmoteMod::IDLE, DeskMod::CHAT, false,
+                       99, 0, 0, false, false, false, "", "", 0, false, "", false, false));
+    presenter.tick(16);
+
+    auto state = presenter.tick(16);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u); // no slide for char_id 99
+}
+
+// ---------------------------------------------------------------------------
+// Courtroom active flag
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, SetCourtroomActiveDoesNotCrash) {
+    presenter.set_courtroom_active(true);
+    EXPECT_NO_FATAL_FAILURE(presenter.tick(16));
+    presenter.set_courtroom_active(false);
+    EXPECT_NO_FATAL_FAILURE(presenter.tick(16));
+}
+
+// ---------------------------------------------------------------------------
+// Multiple rapid messages
+// ---------------------------------------------------------------------------
+
+TEST_F(AOCourtroomPresenterTest, RapidMessagesDoNotCrash) {
+    for (int i = 0; i < 20; i++) {
+        send_ic("Phoenix", "Message " + std::to_string(i), i % 2 == 0 ? "def" : "pro");
+    }
+    auto state = presenter.tick(16);
+    EXPECT_GE(state.get_layer_groups().size(), 1u);
+}

--- a/tests/ao/game/test_AOMessagePlayer.cpp
+++ b/tests/ao/game/test_AOMessagePlayer.cpp
@@ -1,0 +1,97 @@
+#include "ao/game/AOMessagePlayer.h"
+
+#include "ao/game/AOTextBox.h"
+#include "asset/AssetLibrary.h"
+#include "asset/MountManager.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+class AOMessagePlayerTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        // Load textbox so it has default text colors (prevents clamp crash)
+        textbox.load(ao_assets);
+    }
+
+    MountManager mounts;
+    AssetLibrary engine_assets{mounts, 0};
+    AOAssetLibrary ao_assets{engine_assets};
+    AOTextBox textbox;
+    AOMessagePlayer player;
+
+    ICMessage make_message(const std::string& character = "Phoenix", const std::string& message = "Hello!",
+                           const std::string& side = "def") {
+        ICMessage msg{};
+        msg.character = character;
+        msg.emote = "normal";
+        msg.message = message;
+        msg.showname = character;
+        msg.side = side;
+        msg.emote_mod = EmoteMod::IDLE;
+        msg.desk_mod = DeskMod::CHAT;
+        msg.text_color = 0;
+        return msg;
+    }
+};
+
+} // namespace
+
+TEST_F(AOMessagePlayerTest, ReturnsICStateWithPosition) {
+    auto result = player.play(make_message(), ao_assets, textbox, false);
+    EXPECT_EQ(result.ic.position, "def");
+}
+
+TEST_F(AOMessagePlayerTest, DeskShownForDefPosition) {
+    auto result = player.play(make_message("Phoenix", "Hi", "def"), ao_assets, textbox, false);
+    EXPECT_TRUE(result.ic.show_desk);
+}
+
+TEST_F(AOMessagePlayerTest, DeskHiddenForJudPosition) {
+    auto result = player.play(make_message("Judge", "Hi", "jud"), ao_assets, textbox, false);
+    EXPECT_FALSE(result.ic.show_desk);
+}
+
+TEST_F(AOMessagePlayerTest, FlipStoredInState) {
+    auto msg = make_message();
+    msg.flip = true;
+    auto result = player.play(msg, ao_assets, textbox, false);
+    EXPECT_TRUE(result.ic.flip);
+}
+
+TEST_F(AOMessagePlayerTest, BlankMessageNotBlocking) {
+    auto result = player.play(make_message("Phoenix", ""), ao_assets, textbox, false);
+    EXPECT_FALSE(result.ic.preanim_blocking);
+}
+
+TEST_F(AOMessagePlayerTest, EmotePlayerStartsOnPlay) {
+    auto result = player.play(make_message(), ao_assets, textbox, false);
+    // Emote player should have been started (even if assets aren't loaded,
+    // the state should advance from NONE)
+    EXPECT_NE(result.ic.emote_player.state(), AOEmotePlayer::State::NONE);
+}
+
+TEST_F(AOMessagePlayerTest, ScreenshakeEffectReturned) {
+    auto msg = make_message();
+    msg.screenshake = true;
+    auto result = player.play(msg, ao_assets, textbox, false);
+    EXPECT_NE(std::find(result.effects.begin(), result.effects.end(), "screenshake"), result.effects.end());
+}
+
+TEST_F(AOMessagePlayerTest, FlashEffectReturned) {
+    auto msg = make_message();
+    msg.realization = true;
+    auto result = player.play(msg, ao_assets, textbox, false);
+    EXPECT_NE(std::find(result.effects.begin(), result.effects.end(), "flash"), result.effects.end());
+}
+
+TEST_F(AOMessagePlayerTest, NoEffectsForNormalMessage) {
+    auto result = player.play(make_message(), ao_assets, textbox, false);
+    EXPECT_TRUE(result.effects.empty());
+}
+
+TEST_F(AOMessagePlayerTest, PrevCharsVisibleInitializedToZero) {
+    auto result = player.play(make_message(), ao_assets, textbox, false);
+    EXPECT_EQ(result.ic.prev_chars_visible, 0);
+}

--- a/tests/ao/game/test_AOSceneCompositor.cpp
+++ b/tests/ao/game/test_AOSceneCompositor.cpp
@@ -1,0 +1,203 @@
+#include "ao/game/AOSceneCompositor.h"
+
+#include "ao/game/AOBackground.h"
+#include "ao/game/AOTextBox.h"
+#include "ao/game/ActiveICState.h"
+#include "asset/AssetLibrary.h"
+#include "asset/ImageAsset.h"
+#include "asset/MountManager.h"
+#include "render/RenderState.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// Create a minimal 1x1 RGBA ImageAsset for testing
+static std::shared_ptr<ImageAsset> make_test_image(const std::string& name) {
+    DecodedFrame frame;
+    frame.pixels = {255, 0, 0, 255}; // 1x1 red pixel
+    frame.width = 1;
+    frame.height = 1;
+    frame.duration_ms = 0;
+    std::vector<DecodedFrame> frames = {frame};
+    return std::make_shared<ImageAsset>(name, "png", std::move(frames));
+}
+
+class AOSceneCompositorTest : public ::testing::Test {
+  protected:
+    AOSceneCompositor compositor;
+    AOBackground background;
+    MountManager mounts;
+    AssetLibrary engine_assets{mounts, 0};
+    AOAssetLibrary ao_assets{engine_assets};
+    AOTextBox textbox;
+
+    void SetUp() override {
+        textbox.load(ao_assets);
+    }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Normal mode (no departing IC)
+// ---------------------------------------------------------------------------
+
+TEST_F(AOSceneCompositorTest, EmptySceneProducesOneGroup) {
+    auto state = compositor.compose(background, nullptr, nullptr, textbox, 0);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u);
+}
+
+TEST_F(AOSceneCompositorTest, NoBackgroundNoICProducesEmptyScene) {
+    auto state = compositor.compose(background, nullptr, nullptr, textbox, 0);
+    auto* scene_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(scene_ptr, nullptr);
+    auto& scene = *scene_ptr;
+    EXPECT_TRUE(scene.get_layers().empty());
+}
+
+TEST_F(AOSceneCompositorTest, ActiveICWithNoFrameAddsNoCharLayer) {
+    ActiveICState ic;
+    auto state = compositor.compose(background, &ic, nullptr, textbox, 0);
+    auto* scene_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(scene_ptr, nullptr);
+    auto& scene = *scene_ptr;
+    EXPECT_TRUE(scene.get_layers().empty());
+}
+
+TEST_F(AOSceneCompositorTest, ActiveICWithDeskButNoAssetAddsNoDeskLayer) {
+    ActiveICState ic;
+    ic.show_desk = true;
+    auto state = compositor.compose(background, &ic, nullptr, textbox, 0);
+    auto* scene_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(scene_ptr, nullptr);
+    auto& scene = *scene_ptr;
+    EXPECT_TRUE(scene.get_layers().empty());
+}
+
+TEST_F(AOSceneCompositorTest, MutableLayerGroupAccessible) {
+    auto state = compositor.compose(background, nullptr, nullptr, textbox, 0);
+    EXPECT_NE(state.get_mutable_layer_group(0), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, MutableLayerGroupNullForMissingId) {
+    auto state = compositor.compose(background, nullptr, nullptr, textbox, 0);
+    EXPECT_EQ(state.get_mutable_layer_group(999), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, TextboxInactiveAddsNoTextLayers) {
+    // Default textbox is INACTIVE
+    ActiveICState ic;
+    auto state = compositor.compose(background, &ic, nullptr, textbox, 0);
+    auto* scene_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(scene_ptr, nullptr);
+    auto& scene = *scene_ptr;
+    // No text layers (z=20, 21, 25) should exist
+    EXPECT_EQ(scene.get_layer(20), nullptr);
+    EXPECT_EQ(scene.get_layer(21), nullptr);
+    EXPECT_EQ(scene.get_layer(25), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, TextboxTickingComposesWithoutCrash) {
+    textbox.start_message("Phoenix", "Hello world", 0, ao_assets.text_colors());
+    ASSERT_EQ(textbox.text_state(), AOTextBox::TextState::TICKING);
+
+    ActiveICState ic;
+    auto state = compositor.compose(background, &ic, nullptr, textbox, 1.0f);
+    EXPECT_EQ(state.get_layer_groups().size(), 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Slide mode (departing IC present)
+// ---------------------------------------------------------------------------
+
+TEST_F(AOSceneCompositorTest, DepartingICProducesTwoGroups) {
+    ActiveICState departing;
+    ActiveICState arriving;
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+    EXPECT_EQ(state.get_layer_groups().size(), 2u);
+}
+
+TEST_F(AOSceneCompositorTest, DepartingGroupUsesSnapshotBg) {
+    ActiveICState departing;
+    departing.bg_asset = make_test_image("old_bg");
+
+    ActiveICState arriving;
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+
+    // Group 0 (departing) should have a layer from the snapshotted bg
+    auto* dep_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(dep_ptr, nullptr);
+    auto& dep_group = *dep_ptr;
+    EXPECT_NE(dep_group.get_layer(0), nullptr); // bg at z=0
+}
+
+TEST_F(AOSceneCompositorTest, DepartingGroupUsesSnapshotDesk) {
+    ActiveICState departing;
+    departing.bg_asset = make_test_image("old_bg");
+    departing.desk_asset = make_test_image("old_desk");
+    departing.show_desk = true;
+
+    ActiveICState arriving;
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+
+    auto* dep_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(dep_ptr, nullptr);
+    auto& dep_group = *dep_ptr;
+    EXPECT_NE(dep_group.get_layer(10), nullptr); // desk at z=10
+}
+
+TEST_F(AOSceneCompositorTest, DepartingGroupNoDeskWhenHidden) {
+    ActiveICState departing;
+    departing.bg_asset = make_test_image("old_bg");
+    departing.desk_asset = make_test_image("old_desk");
+    departing.show_desk = false;
+
+    ActiveICState arriving;
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+
+    auto* dep_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(dep_ptr, nullptr);
+    auto& dep_group = *dep_ptr;
+    EXPECT_EQ(dep_group.get_layer(10), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, ArrivingGroupUsesLiveBackground) {
+    // departing has a snapshot, arriving should use the shared background
+    ActiveICState departing;
+    departing.bg_asset = make_test_image("old_bg");
+
+    ActiveICState arriving;
+    // background has no asset loaded (empty), so arriving group has no bg layer
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+    auto* arr_ptr = state.get_mutable_layer_group(1);
+    ASSERT_NE(arr_ptr, nullptr);
+    auto& arr_group = *arr_ptr;
+    // No bg layer because shared background has no asset
+    EXPECT_EQ(arr_group.get_layer(0), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, TextboxLayersOnlyInArrivingGroup) {
+    textbox.start_message("Phoenix", "Hello", 0, ao_assets.text_colors());
+
+    ActiveICState departing;
+    departing.bg_asset = make_test_image("old_bg");
+    ActiveICState arriving;
+
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+
+    // Departing group should have no textbox layers
+    auto* dep_ptr = state.get_mutable_layer_group(0);
+    ASSERT_NE(dep_ptr, nullptr);
+    auto& dep_group = *dep_ptr;
+    EXPECT_EQ(dep_group.get_layer(20), nullptr);
+    EXPECT_EQ(dep_group.get_layer(21), nullptr);
+}
+
+TEST_F(AOSceneCompositorTest, BothGroupsMutableDuringSlide) {
+    ActiveICState departing;
+    ActiveICState arriving;
+    auto state = compositor.compose(background, &arriving, &departing, textbox, 0);
+    EXPECT_NE(state.get_mutable_layer_group(0), nullptr);
+    EXPECT_NE(state.get_mutable_layer_group(1), nullptr);
+}

--- a/tests/ao/game/test_SlideEffect.cpp
+++ b/tests/ao/game/test_SlideEffect.cpp
@@ -1,0 +1,95 @@
+#include "ao/game/effects/SlideEffect.h"
+
+#include "render/Layer.h"
+
+#include <gtest/gtest.h>
+
+class SlideEffectTest : public ::testing::Test {
+  protected:
+    SlideEffect effect;
+    LayerGroup departing;
+    LayerGroup arriving;
+};
+
+TEST_F(SlideEffectTest, InactiveByDefault) {
+    EXPECT_FALSE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, ActiveAfterTrigger) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    EXPECT_TRUE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, StopMakesInactive) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.stop();
+    EXPECT_FALSE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, TickWithoutTriggerDoesNotCrash) {
+    EXPECT_NO_FATAL_FAILURE(effect.tick(16));
+    EXPECT_FALSE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, ActiveDuringPreDelay) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(100); // < 300ms bookend
+    EXPECT_TRUE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, ActiveDuringSlide) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(350); // past 300ms pre-delay, into slide
+    EXPECT_TRUE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, InactiveAfterFullDuration) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(300); // pre-delay done
+    effect.tick(500); // slide done
+    effect.tick(300); // post-delay done
+    EXPECT_FALSE(effect.is_active());
+}
+
+TEST_F(SlideEffectTest, PreDelayArrivingIsOffscreen) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(100); // still in pre-delay
+
+    effect.apply_in(arriving);
+    auto mat = arriving.transform().get_local_transform();
+    EXPECT_FLOAT_EQ(mat.m[12], 2.0f); // off-screen right
+}
+
+TEST_F(SlideEffectTest, PreDelayDepartingIsAtOrigin) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(100); // still in pre-delay
+
+    effect.apply_out(departing);
+    // No transform applied during pre-delay — departing stays at origin
+    auto mat = departing.transform().get_local_transform();
+    EXPECT_FLOAT_EQ(mat.m[12], 0.0f);
+}
+
+TEST_F(SlideEffectTest, SlidePhaseMovesBothGroups) {
+    effect.configure(SlideEffect::Direction::LEFT, 500);
+    effect.trigger();
+    effect.tick(550); // 300ms pre-delay + 250ms into slide (halfway)
+
+    effect.apply_out(departing);
+    effect.apply_in(arriving);
+
+    float out_x = departing.transform().get_local_transform().m[12];
+    float in_x = arriving.transform().get_local_transform().m[12];
+    // Departing should be moving left (negative)
+    EXPECT_LT(out_x, 0.0f);
+    // Arriving should be between 2.0 and 0 (moving in from right)
+    EXPECT_GT(in_x, 0.0f);
+    EXPECT_LT(in_x, 2.0f);
+}


### PR DESCRIPTION
## Summary

Decomposes `AOCourtroomPresenter` into focused components and adds slide transition support between courtroom positions.

### Presenter decomposition
- **`ActiveICState`** — extracted into own header; per-IC-message state with emote/blip players, enabling dual character rendering during slides
- **`AOSceneCompositor`** — scene composition logic extracted from `tick()`; produces `RenderState` from background, IC states, and textbox
- **`AOMessagePlayer`** — IC message setup extracted from `play_message()`; handles character sheet lookup, emote start, SFX, blips, IC log
- **Named effect dispatch** — effects stored as `{name, ISceneEffect*}` pairs; message player returns effect names to trigger, eliminating parallel if-chains

### Slide transitions
- **`SlideEffect`** — `ISceneEffect` using `TransformAnimator` with `QUAD_IN_OUT` easing and 300ms bookend delays
- **Position data** — `AOAssetLibrary::position_origin()` and `slide_duration_ms()` read from background `design.ini`
- **Protocol** — `SLIDE` flag parsed from MS packet field 31, added to `ICMessageEvent` and `ICMessage`
- **Wiring** — on position change with valid origins/duration, old `ActiveICState` moves to `departing_ic_` (emote keeps running), slide effect triggers, `departing_ic_` cleaned up when slide finishes
- `RenderState::get_mutable_layer_group()` added so effects can be applied after composition

### Bug fixes in cleanup pass
- Fixed `const` mismatch on compositor's `compose()` signature
- Slide effect separated from message effects array (not stopped on new message)
- Removed dead `theme_retry_ms_` member
- Eliminated circular includes via `ActiveICState.h` extraction

## Test plan
- [ ] Normal IC messages display correctly (no regression)
- [ ] Preanim blocking still defers textbox
- [ ] Area changes clear all state
- [ ] Slide transitions animate between positions when design.ini has origins + duration configured
- [ ] Departing character visible during slide, cleaned up after

🤖 Generated with [Claude Code](https://claude.com/claude-code)