### PR TITLE
AONX v2: character, asset, and server info endpoints

### DIFF
--- a/doc/aonx/openapi.yaml
+++ b/doc/aonx/openapi.yaml
@@ -292,8 +292,9 @@ paths:
       operationId: getArea
       summary: Get Area State
       description: |
-        Returns the full state of an area — metadata, current background,
-        music, health bars, timers. Use this to hydrate client state after
+        Returns area metadata and playback state — current background,
+        music, health bars, timers. Evidence and players are available
+        via their own endpoints. Use this to hydrate client state after
         joining or reconnecting. Use `_` for current area.
       security:
         - sessionToken: []
@@ -1589,6 +1590,9 @@ components:
     IcMessage:
       type: object
       properties:
+        schema_version:
+          type: integer
+          description: Schema version for IcMessage. Currently 1.
         objects:
           type: array
           items:
@@ -1738,8 +1742,8 @@ components:
           type: string
           description: Name displayed above the text box.
         color:
-          type: integer
-          description: Text color index.
+          type: string
+          description: Text color as hex (e.g. "#FFFFFF", "#00FF00"). Default "#FFFFFF".
         additive:
           type: boolean
           description: Append to existing text instead of replacing. Default false.
@@ -1910,7 +1914,15 @@ components:
           enum: [show, hide]
           description: Whether to show the desk overlay for this emote.
         sfx:
-          $ref: "#/components/schemas/AudioCue"
+          type: object
+          properties:
+            asset:
+              type: string
+              description: Asset hash of the sound file.
+            delay_ms:
+              type: integer
+              description: Delay before playing. Default 0.
+          description: Sound effect for this emote. Played on "start" by default when the client builds the IC message.
         effects:
           type: array
           items:
@@ -2015,6 +2027,10 @@ components:
 
     # -------------------------------------------------------------------------
     # SSE event schemas
+    #
+    # All SSE events carry a `schema_version` integer field (currently 1).
+    # Omitted from individual schemas below for brevity — it is present
+    # on every event payload.
     # -------------------------------------------------------------------------
     IcMessageEvent:
       type: object


### PR DESCRIPTION
## Summary

Complete AONX v2 REST API specification covering the full protocol surface.

### Session
- Create (with HDID, optional auth), renew, delete

### Server
- Player count, MOTD

### Areas
- CRUD with hierarchical paths (e.g. `courtroom/1`)
- Join, player list, full state hydration
- `_` for current area, `*` for all areas on scoped endpoints

### Chat
- **IC messages**: Composition-based model — objects with named states, keyframed transforms, event-driven transitions, shader effects as content-addressed assets, consumed event queue for sequencing
- OOC messages

### Area actions
- Background (sets shared area state; IC messages reference positions via `ref`)
- Music (with fade/sync effects)
- Health bars, timers

### Evidence
- Full CRUD by ID

### Characters
- List (hash + availability), select, get manifest
- Manifests define emotes as state maps with suggested event wiring
- Background manifests define position layers referenced by IC compositions

### Assets
- Content-addressed blob fetch (`GET /asset/{hash}`, immutable caching)
- Background and music listing

### Moderation
- Envelope-based: action is a free string, params unconstrained
- Submit, query active, revoke, discover supported actions

### Events (SSE)
- Server-Sent Events stream for all broadcasts
- IC/OOC messages, area updates, background/music/HP/timer changes, evidence, presence, character availability, moderation actions

### Key design decisions
- IC messages are a composition engine: 6 primitives (objects, text, audio, effects, transitions, events) express everything from simple emotes to multi-phase animations with shader effects
- Shaders are content-addressed assets — new visual effects need no protocol changes
- `ObjectComposition.ref` unifies background layers and character sprites as the same primitive
- `_prev` ref captures previous message end-state for smooth slide transitions
- ZIP is authoring format only; server serves individual blobs by hash
- SSE instead of WebSocket (one-way push, works through HTTP/2 reverse proxies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)