### PR TITLE
Fix crash on malformed MS: safe_dispatch boundary + safe_stoi

### DIFF
--- a/plugins/net/ao/AOClient.cpp
+++ b/plugins/net/ao/AOClient.cpp
@@ -8,7 +8,6 @@
 #include "event/OutgoingHealthBarEvent.h"
 #include "event/OutgoingMusicEvent.h"
 #include "platform/HardwareId.h"
-#include "utils/Log.h"
 
 AOClient::AOClient() {
     ao_register_packet_types();
@@ -27,18 +26,10 @@ void AOClient::on_message(const std::string& message) {
         std::string complete_msg = incomplete_buf.substr(0, delimiter_pos + std::strlen(AOPacket::DELIMITER));
         incomplete_buf.erase(0, delimiter_pos + std::strlen(AOPacket::DELIMITER));
 
-        try {
-            std::unique_ptr<AOPacket> packet = AOPacket::deserialize(complete_msg);
-            if (packet->is_valid()) {
-                packet->handle(*this);
-            }
-            else {
-                Log::log_print(ERR, "Failed to parse AOPacket from message: %s", complete_msg.c_str());
-            }
-        }
-        catch (const std::exception& e) {
-            Log::log_print(ERR, "Exception while handling message: %s, Error: %s", complete_msg.c_str(), e.what());
-        }
+        // All exception handling — parse errors, handler bugs, bad numeric
+        // fields — is centralized inside safe_dispatch. Never call
+        // AOPacket::deserialize + handle() directly; see AOPacket.h for why.
+        ao_packet::safe_dispatch(complete_msg, "AOClient", [this](AOPacket& pkt) { pkt.handle(*this); });
     }
 }
 

--- a/plugins/net/ao/AOPacket.cpp
+++ b/plugins/net/ao/AOPacket.cpp
@@ -70,3 +70,43 @@ void AOPacket::handle(AOClient& cli) {
 void AOPacket::handle_server(AOServer& /*server*/, ServerSession& /*session*/) {
     Log::log_print(DEBUG, "Unhandled server packet %s", header.c_str());
 }
+
+// ---------------------------------------------------------------------------
+// ao_packet::log_bad_packet
+// ---------------------------------------------------------------------------
+
+namespace ao_packet {
+
+// Cap the logged packet preview. MS can legitimately reach ~500 bytes, but a
+// hostile client could send arbitrarily long garbage; we refuse to pay the log
+// bandwidth for them. 256 bytes covers every well-formed packet type comfortably.
+static constexpr size_t MAX_LOG_PREVIEW = 256;
+
+// Strip non-printable bytes so log sinks (journald, CloudWatch, terminals)
+// can't be confused by embedded control chars, ANSI escapes, or binary blobs
+// in hostile payloads.
+static std::string redact_for_log(const std::string& wire) {
+    std::string out;
+    const size_t limit = std::min(wire.size(), MAX_LOG_PREVIEW);
+    out.reserve(limit + 3);
+    for (size_t i = 0; i < limit; ++i) {
+        const unsigned char c = static_cast<unsigned char>(wire[i]);
+        out += (c >= 32 && c < 127) ? static_cast<char>(c) : '?';
+    }
+    if (wire.size() > MAX_LOG_PREVIEW)
+        out += "...";
+    return out;
+}
+
+void log_bad_packet(std::string_view peer_label, const std::string& wire, std::string_view reason) {
+    // log_print is printf-style; copy the views into std::string so we can
+    // pass stable C strings without worrying about string_view's non-null-
+    // terminated contract.
+    const std::string peer(peer_label);
+    const std::string reason_str(reason);
+    const std::string preview = redact_for_log(wire);
+    Log::log_print(WARNING, "AO: malformed packet from [%s]: %s — wire=%s", peer.c_str(), reason_str.c_str(),
+                   preview.c_str());
+}
+
+} // namespace ao_packet

--- a/plugins/net/ao/AOPacket.h
+++ b/plugins/net/ao/AOPacket.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class AOClient;
@@ -49,3 +50,80 @@ class AOPacket {
     std::string header;
     std::vector<std::string> fields;
 };
+
+// ---------------------------------------------------------------------------
+// Safe deserialize + dispatch boundary
+// ---------------------------------------------------------------------------
+//
+// Both `AOClient` (processing server→client frames) and `AOServer` (processing
+// client→server frames) must cross this boundary before any typed packet
+// handler runs. Packet constructors can throw (`std::stoi` on a non-numeric
+// field, `PacketFormatException` from validated parsers) and handlers can
+// throw (`ProtocolStateException`, lookup failures, downstream bugs) — a
+// single uncaught exception on a worker thread calls `std::terminate()` and
+// kills the process.
+//
+// Callers should never invoke `AOPacket::deserialize` + a handler in sequence
+// directly. Always go through `ao_packet::safe_dispatch`, which wraps *both*
+// steps in a single try/catch, logs failures with a peer label and a
+// redacted wire preview, and returns a categorized `DispatchResult` so the
+// caller can update metrics without re-implementing exception handling.
+namespace ao_packet {
+
+enum class DispatchResult {
+    Ok,            ///< Packet parsed and handler returned normally.
+    ParseFailed,   ///< Exception thrown during `AOPacket::deserialize`.
+    HandlerFailed, ///< Handler threw after a successful parse.
+    InvalidPacket, ///< Parsed to an `AOPacket` whose `is_valid()` is false.
+};
+
+/// Log a malformed packet at WARNING. Printable ASCII is forwarded
+/// verbatim; other bytes are replaced with '?' and the preview is
+/// truncated so adversarial payloads cannot scramble the terminal or
+/// inflate log volume.
+///
+/// Out-of-line so the template below does not pull in `utils/Log.h`
+/// for every translation unit that includes `AOPacket.h`.
+void log_bad_packet(std::string_view peer_label, const std::string& wire, std::string_view reason);
+
+/// Deserialize `wire` and invoke `dispatch(AOPacket&)` on success.
+///
+/// All exceptions — from deserialization *or* from the dispatch callback —
+/// are caught, logged via `log_bad_packet`, and suppressed. The framing
+/// loop that called this function can safely continue with the next
+/// packet in the buffer.
+///
+/// @tparam DispatchFn Callable with signature `void(AOPacket&)`.
+/// @param wire        Fully framed packet content (including `#%` delimiter).
+/// @param peer_label  Short human label for log context — caller's choice
+///                    of granularity (e.g. `"AOClient"`, `"client=42 10.0.0.1"`).
+/// @param dispatch    Invoked with the parsed packet if deserialization
+///                    succeeded and the packet reports `is_valid()`.
+///
+/// @returns `DispatchResult` indicating the outcome. Callers typically
+/// use this to increment per-category metrics counters.
+template <typename DispatchFn>
+DispatchResult safe_dispatch(const std::string& wire, std::string_view peer_label, DispatchFn&& dispatch) {
+    std::unique_ptr<AOPacket> pkt;
+    try {
+        pkt = AOPacket::deserialize(wire);
+    }
+    catch (const std::exception& e) {
+        log_bad_packet(peer_label, wire, e.what());
+        return DispatchResult::ParseFailed;
+    }
+    if (!pkt || !pkt->is_valid()) {
+        log_bad_packet(peer_label, wire, "invalid packet (is_valid() == false)");
+        return DispatchResult::InvalidPacket;
+    }
+    try {
+        dispatch(*pkt);
+        return DispatchResult::Ok;
+    }
+    catch (const std::exception& e) {
+        log_bad_packet(peer_label, wire, e.what());
+        return DispatchResult::HandlerFailed;
+    }
+}
+
+} // namespace ao_packet

--- a/plugins/net/ao/AOServer.cpp
+++ b/plugins/net/ao/AOServer.cpp
@@ -124,8 +124,8 @@ void AOServer::on_client_message(uint64_t client_id, const std::string& raw) {
         // The return code drives metric bucketing and error replies to the
         // client below.
         const std::string peer_label = format_client_id(client_id) + " " + client_addr;
-        const auto result =
-            ao_packet::safe_dispatch(packet_str, peer_label, [this, client_id](AOPacket& pkt) { dispatch(client_id, pkt); });
+        const auto result = ao_packet::safe_dispatch(packet_str, peer_label,
+                                                     [this, client_id](AOPacket& pkt) { dispatch(client_id, pkt); });
 
         switch (result) {
         case ao_packet::DispatchResult::Ok:

--- a/plugins/net/ao/AOServer.cpp
+++ b/plugins/net/ao/AOServer.cpp
@@ -118,23 +118,27 @@ void AOServer::on_client_message(uint64_t client_id, const std::string& raw) {
         Log::log_print(VERBOSE, "AO [%s %s] <<< %s", format_client_id(client_id).c_str(), client_addr.c_str(),
                        packet_str.c_str());
 
-        auto packet = AOPacket::deserialize(packet_str);
-        if (packet) {
-            try {
-                dispatch(client_id, *packet);
-            }
-            catch (const std::exception& e) {
-                ao_errors_.labels({"dispatch"}).inc();
-                Log::log_print(WARNING, "AO: error handling packet from %s: %s", format_client_id(client_id).c_str(),
-                               e.what());
-                // Send error to client before disconnect
-                send(client_id, AOPacket("CT", {"Server", "[ERROR] " + std::string(e.what()), "1"}));
-            }
-        }
-        else {
+        // All exception handling — parse errors, handler bugs, bad numeric
+        // fields — is centralized inside safe_dispatch. Never call
+        // AOPacket::deserialize + handle_server() directly; see AOPacket.h.
+        // The return code drives metric bucketing and error replies to the
+        // client below.
+        const std::string peer_label = format_client_id(client_id) + " " + client_addr;
+        const auto result =
+            ao_packet::safe_dispatch(packet_str, peer_label, [this, client_id](AOPacket& pkt) { dispatch(client_id, pkt); });
+
+        switch (result) {
+        case ao_packet::DispatchResult::Ok:
+            break;
+        case ao_packet::DispatchResult::ParseFailed:
+        case ao_packet::DispatchResult::InvalidPacket:
             ao_errors_.labels({"parse"}).inc();
-            Log::log_print(WARNING, "AO: malformed packet from %s", format_client_id(client_id).c_str());
             send(client_id, AOPacket("CT", {"Server", "[ERROR] Malformed packet — could not parse", "1"}));
+            break;
+        case ao_packet::DispatchResult::HandlerFailed:
+            ao_errors_.labels({"dispatch"}).inc();
+            send(client_id, AOPacket("CT", {"Server", "[ERROR] Internal error handling packet", "1"}));
+            break;
         }
     }
 }

--- a/plugins/net/ao/PacketTypes.cpp
+++ b/plugins/net/ao/PacketTypes.cpp
@@ -1,6 +1,44 @@
 #include "PacketTypes.h"
 
+#include "utils/Log.h"
+
 #include <algorithm>
+#include <charconv>
+#include <string_view>
+
+// ---------------------------------------------------------------------------
+// safe_stoi — non-throwing integer parser for wire protocol fields.
+//
+// `std::stoi` throws `std::invalid_argument` on non-numeric input and
+// `std::out_of_range` on overflow, neither of which is appropriate when
+// parsing untrusted client data. A single bad numeric field (see the webAO
+// `NaN` in the `sfx_delay` slot of MS) would otherwise escape the packet
+// constructor, bubble up through `AOPacket::deserialize`, and — if any
+// caller forgets to wrap the call in try/catch — terminate a worker thread.
+//
+// This helper uses `std::from_chars` (which never throws and never allocates)
+// and returns `default_value` on empty input, non-numeric content, trailing
+// garbage, or out-of-range values. A DEBUG log line records the bad value
+// so operators can diagnose misbehaving clients via log-level toggle without
+// dropping the surrounding packet.
+//
+// Field names are passed as string literals for the log message; callers
+// should use the canonical AO field index (e.g. "MS[9]" for sfx_delay).
+// ---------------------------------------------------------------------------
+static int safe_stoi(std::string_view field, const char* field_name = "?", int default_value = 0) {
+    if (field.empty())
+        return default_value;
+    int value = 0;
+    const char* begin = field.data();
+    const char* end = field.data() + field.size();
+    auto [ptr, ec] = std::from_chars(begin, end, value);
+    if (ec != std::errc{} || ptr != end) {
+        Log::log_print(DEBUG, "AO: non-numeric field %s=\"%.*s\" (using %d)", field_name,
+                       static_cast<int>(field.size()), field.data(), default_value);
+        return default_value;
+    }
+    return value;
+}
 
 // AO protocol encoding: special characters must be escaped in field values.
 static std::string ao_encode(const std::string& s) {
@@ -89,7 +127,7 @@ AOPacketIDClient::AOPacketIDClient(const std::vector<std::string>& fields) : AOP
     // 3 fields = server→client: player_number, software, version
     // 2 fields = client→server: software, version
     if (fields.size() >= 3) {
-        player_number = std::stoi(fields[0]);
+        player_number = safe_stoi(fields[0], "ID[0]");
         software = fields[1];
         version = fields[2];
     }
@@ -116,8 +154,8 @@ PacketRegistrar AOPacketPN::registrar("PN", [](const auto& f) { return std::make
 
 AOPacketPN::AOPacketPN(const std::vector<std::string>& fields) : AOPacket("PN", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        current_players = std::stoi(fields[0]);
-        max_players = std::stoi(fields[1]);
+        current_players = safe_stoi(fields[0], "PN[0]");
+        max_players = safe_stoi(fields[1], "PN[1]");
         server_description = fields.size() > 2 ? ao_decode(fields[2]) : "";
     }
 }
@@ -155,9 +193,9 @@ PacketRegistrar AOPacketSI::registrar("SI", [](const auto& f) { return std::make
 
 AOPacketSI::AOPacketSI(const std::vector<std::string>& fields) : AOPacket("SI", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        character_count = std::stoi(fields[0]);
-        evidence_count = std::stoi(fields[1]);
-        music_count = std::stoi(fields[2]);
+        character_count = safe_stoi(fields[0], "SI[0]");
+        evidence_count = safe_stoi(fields[1], "SI[1]");
+        music_count = safe_stoi(fields[2], "SI[2]");
     }
 }
 
@@ -317,21 +355,23 @@ AOPacketMS::AOPacketMS(const ICMessageData& d)
 AOPacketMS::AOPacketMS(const std::vector<std::string>& fields) : AOPacket("MS", fields) {
     if (fields.size() >= MIN_FIELDS) {
         // "chat" means use default desk behavior based on position
-        desk_mod = (fields[0] == "chat") ? -1 : std::stoi(fields[0]);
+        desk_mod = (fields[0] == "chat") ? -1 : safe_stoi(fields[0], "MS[0]");
         pre_emote = ao_decode(fields[1]);
         character = ao_decode(fields[2]);
         emote = ao_decode(fields[3]);
         message = ao_decode(fields[4]);
         side = ao_decode(fields[5]);
         sfx_name = ao_decode(fields[6]);
-        emote_mod = std::stoi(fields[7]);
-        char_id = std::stoi(fields[8]);
-        sfx_delay = std::stoi(fields[9]);
-        objection_mod = std::stoi(fields[10]);
+        emote_mod = safe_stoi(fields[7], "MS[7]");
+        char_id = safe_stoi(fields[8], "MS[8]");
+        // sfx_delay: webAO has been observed sending "NaN" here when the
+        // char.ini's [SoundT] block is malformed. safe_stoi recovers with 0.
+        sfx_delay = safe_stoi(fields[9], "MS[9]");
+        objection_mod = safe_stoi(fields[10], "MS[10]");
         // fields[11] = evidence_id (skipped)
         flip = fields[12] == "1";
         realization = fields[13] == "1";
-        text_color = std::stoi(fields[14]);
+        text_color = safe_stoi(fields[14], "MS[14]");
 
         // Showname (optional field 15)
         showname = fields.size() > 15 ? ao_decode(fields[15]) : character;
@@ -384,15 +424,15 @@ AOPacketMC::AOPacketMC(const std::string& name, int char_id, const std::string& 
 AOPacketMC::AOPacketMC(const std::vector<std::string>& fields) : AOPacket("MC", fields) {
     if (fields.size() >= MIN_FIELDS) {
         name = ao_decode(fields[0]);
-        char_id = std::stoi(fields[1]);
+        char_id = safe_stoi(fields[1], "MC[1]");
         if (fields.size() > 2)
             showname = ao_decode(fields[2]);
         if (fields.size() > 3)
-            looping = std::stoi(fields[3]);
+            looping = safe_stoi(fields[3], "MC[3]");
         if (fields.size() > 4)
-            channel = std::stoi(fields[4]);
+            channel = safe_stoi(fields[4], "MC[4]");
         if (fields.size() > 5)
-            effect_flags = std::stoi(fields[5]);
+            effect_flags = safe_stoi(fields[5], "MC[5]");
     }
 }
 
@@ -404,7 +444,7 @@ PacketRegistrar AOPacketARUP::registrar("ARUP", [](const auto& f) { return std::
 
 AOPacketARUP::AOPacketARUP(const std::vector<std::string>& fields) : AOPacket("ARUP", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        arup_type = std::stoi(fields[0]);
+        arup_type = safe_stoi(fields[0], "ARUP[0]");
         for (auto it = fields.begin() + 1; it != fields.end(); ++it)
             values.push_back(ao_decode(*it));
     }
@@ -431,7 +471,7 @@ PacketRegistrar AOPacketPV::registrar("PV", [](const auto& f) { return std::make
 
 AOPacketPV::AOPacketPV(const std::vector<std::string>& fields) : AOPacket("PV", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        char_id = std::stoi(fields[2]);
+        char_id = safe_stoi(fields[2], "PV[2]");
     }
 }
 
@@ -471,8 +511,8 @@ PacketRegistrar AOPacketHP::registrar("HP", [](const auto& f) { return std::make
 
 AOPacketHP::AOPacketHP(const std::vector<std::string>& fields) : AOPacket("HP", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        side = std::stoi(fields[0]);
-        value = std::stoi(fields[1]);
+        side = safe_stoi(fields[0], "HP[0]");
+        value = safe_stoi(fields[1], "HP[1]");
     }
 }
 
@@ -484,10 +524,18 @@ PacketRegistrar AOPacketTI::registrar("TI", [](const auto& f) { return std::make
 
 AOPacketTI::AOPacketTI(const std::vector<std::string>& fields) : AOPacket("TI", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        timer_id = std::stoi(fields[0]);
-        action = std::stoi(fields[1]);
-        if (fields.size() > 2)
-            time_ms = std::stoll(fields[2]);
+        timer_id = safe_stoi(fields[0], "TI[0]");
+        action = safe_stoi(fields[1], "TI[1]");
+        if (fields.size() > 2) {
+            // time_ms is int64 — use std::from_chars directly to avoid
+            // truncating the value through safe_stoi's int path.
+            long long parsed = 0;
+            auto [p, ec] = std::from_chars(fields[2].data(), fields[2].data() + fields[2].size(), parsed);
+            if (ec == std::errc{} && p == fields[2].data() + fields[2].size())
+                time_ms = parsed;
+            else
+                Log::log_print(DEBUG, "AO: non-numeric field TI[2]=\"%s\" (using 0)", fields[2].c_str());
+        }
     }
 }
 
@@ -509,8 +557,8 @@ PacketRegistrar AOPacketPR::registrar("PR", [](const auto& f) { return std::make
 
 AOPacketPR::AOPacketPR(const std::vector<std::string>& fields) : AOPacket("PR", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        player_id = std::stoi(fields[0]);
-        update_type = std::stoi(fields[1]);
+        player_id = safe_stoi(fields[0], "PR[0]");
+        update_type = safe_stoi(fields[1], "PR[1]");
     }
 }
 
@@ -522,8 +570,8 @@ PacketRegistrar AOPacketPU::registrar("PU", [](const auto& f) { return std::make
 
 AOPacketPU::AOPacketPU(const std::vector<std::string>& fields) : AOPacket("PU", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        player_id = std::stoi(fields[0]);
-        data_type = std::stoi(fields[1]);
+        player_id = safe_stoi(fields[0], "PU[0]");
+        data_type = safe_stoi(fields[1], "PU[1]");
         data = ao_decode(fields[2]);
     }
 }
@@ -567,12 +615,7 @@ PacketRegistrar AOPacketMA::registrar("MA", [](const auto& f) { return std::make
 AOPacketMA::AOPacketMA(const std::vector<std::string>& fields) : AOPacket("MA", fields) {
     if (fields.size() >= MIN_FIELDS) {
         target_ipid = fields[0];
-        try {
-            duration = std::stoi(fields[1]);
-        }
-        catch (...) {
-            duration = 0;
-        }
+        duration = safe_stoi(fields[1], "MA[1]");
         reason = fields.size() > 2 ? ao_decode(fields[2]) : "No reason given";
     }
 }
@@ -610,12 +653,7 @@ PacketRegistrar AOPacketEE::registrar("EE", [](const auto& f) { return std::make
 
 AOPacketEE::AOPacketEE(const std::vector<std::string>& fields) : AOPacket("EE", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        try {
-            ev_id = std::stoi(fields[0]);
-        }
-        catch (...) {
-            ev_id = -1;
-        }
+        ev_id = safe_stoi(fields[0], "EE[0]", -1);
         ev_name = ao_decode(fields[1]);
         ev_description = ao_decode(fields[2]);
         ev_image = ao_decode(fields[3]);
@@ -630,12 +668,7 @@ PacketRegistrar AOPacketDE::registrar("DE", [](const auto& f) { return std::make
 
 AOPacketDE::AOPacketDE(const std::vector<std::string>& fields) : AOPacket("DE", fields) {
     if (fields.size() >= MIN_FIELDS) {
-        try {
-            ev_id = std::stoi(fields[0]);
-        }
-        catch (...) {
-            ev_id = -1;
-        }
+        ev_id = safe_stoi(fields[0], "DE[0]", -1);
     }
 }
 

--- a/tests/ao/net/test_AOPacket.cpp
+++ b/tests/ao/net/test_AOPacket.cpp
@@ -81,3 +81,60 @@ TEST(AOPacket, IsValidFalseForDefaultConstruct) {
     AOPacket pkt;
     EXPECT_FALSE(pkt.is_valid());
 }
+
+// ---------------------------------------------------------------------------
+// ao_packet::safe_dispatch — crash-safety boundary
+// ---------------------------------------------------------------------------
+//
+// Regression coverage for the "webAO MS#...#NaN#..." crash: before this
+// change, an un-parseable numeric field inside an MS packet constructor
+// threw std::invalid_argument, which escaped AOPacket::deserialize, escaped
+// AOServer::on_client_message (deserialize was called outside the try/catch),
+// escaped the worker thread lambda, and terminated the entire kagami process
+// with std::terminate. safe_dispatch wraps *both* parse and dispatch in a
+// single try/catch so no exception can leak out to the worker thread.
+
+TEST(AOPacketSafeDispatch, ValidPacketIsDispatchedOnce) {
+    int calls = 0;
+    auto result = ao_packet::safe_dispatch("HI#myhwid#%", "unit-test", [&](AOPacket& pkt) {
+        ++calls;
+        EXPECT_EQ(pkt.get_header(), "HI");
+    });
+    EXPECT_EQ(result, ao_packet::DispatchResult::Ok);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST(AOPacketSafeDispatch, ParseErrorIsSwallowed) {
+    int calls = 0;
+    // Missing #% delimiter — AOPacket::deserialize throws std::invalid_argument.
+    auto result = ao_packet::safe_dispatch("RC", "unit-test", [&](AOPacket&) { ++calls; });
+    EXPECT_EQ(result, ao_packet::DispatchResult::ParseFailed);
+    EXPECT_EQ(calls, 0);
+}
+
+TEST(AOPacketSafeDispatch, HandlerExceptionIsSwallowed) {
+    auto result = ao_packet::safe_dispatch("HI#myhwid#%", "unit-test",
+                                           [](AOPacket&) { throw std::runtime_error("handler blew up"); });
+    EXPECT_EQ(result, ao_packet::DispatchResult::HandlerFailed);
+}
+
+TEST(AOPacketSafeDispatch, WebaoMsNanDoesNotCrash) {
+    // Real payload captured from webAO parsing neuro/char.ini — field 9
+    // (sfx_delay) is "NaN" because the INI's [SoundT] block is malformed.
+    // Before the fix, AOPacketMS's std::stoi threw std::invalid_argument,
+    // which escaped deserialize and killed the server process.
+    // After the fix, safe_stoi inside the MS constructor recovers with 0,
+    // so the packet is dispatched normally. safe_dispatch would also catch
+    // any exception that did escape — belt-and-suspenders.
+    constexpr const char* webao_wire =
+        "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = 0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
+
+    bool dispatched = false;
+    auto result = ao_packet::safe_dispatch(webao_wire, "unit-test", [&](AOPacket& pkt) {
+        dispatched = true;
+        EXPECT_EQ(pkt.get_header(), "MS");
+    });
+
+    EXPECT_EQ(result, ao_packet::DispatchResult::Ok);
+    EXPECT_TRUE(dispatched);
+}

--- a/tests/ao/net/test_AOPacket.cpp
+++ b/tests/ao/net/test_AOPacket.cpp
@@ -126,8 +126,8 @@ TEST(AOPacketSafeDispatch, WebaoMsNanDoesNotCrash) {
     // After the fix, safe_stoi inside the MS constructor recovers with 0,
     // so the packet is dispatched normally. safe_dispatch would also catch
     // any exception that did escape — belt-and-suspenders.
-    constexpr const char* webao_wire =
-        "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = 0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
+    constexpr const char* webao_wire = "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = "
+                                       "0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
 
     bool dispatched = false;
     auto result = ao_packet::safe_dispatch(webao_wire, "unit-test", [&](AOPacket& pkt) {

--- a/tests/ao/net/test_NewPackets.cpp
+++ b/tests/ao/net/test_NewPackets.cpp
@@ -209,3 +209,42 @@ TEST(AOPacketMS, DeserializeRoundTrip) {
     ASSERT_NE(pkt, nullptr);
     EXPECT_EQ(pkt->serialize(), "MS#1#objecting#Phoenix#normal#Hello#def#sfx#1#42#0#0#0#0#0#0#%");
 }
+
+// Regression: webAO parses a malformed [SoundT] block in char.ini as
+// `parseInt("02 = 03 = ...") === NaN`, so the MS packet ships the literal
+// string "NaN" in field 9 (sfx_delay). Before the safe_stoi refactor, the
+// AOPacketMS constructor hit `std::stoi("NaN")` and threw, and because
+// AOServer::on_client_message called AOPacket::deserialize *outside* its
+// try/catch, the exception tore through the worker thread and crashed the
+// whole kagami process. Both halves of that defense are now covered:
+//   1. AOPacketMS constructor recovers gracefully from non-numeric fields
+//      (sfx_delay defaults to 0 — see safe_stoi in PacketTypes.cpp).
+//   2. ao_packet::safe_dispatch catches any exception that still escapes
+//      (see test_AOPacket.cpp::AOPacketSafeDispatch).
+TEST(AOPacketMS, DeserializeWebaoNaNSfxDelayDoesNotThrow) {
+    auto& ch = EventManager::instance().get_channel<ICMessageEvent>();
+    drain(ch);
+
+    AOClient cli;
+    cli.conn_state = CONNECTED;
+
+    constexpr const char* webao_wire =
+        "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = 0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
+
+    // Constructor must not throw even though field 9 ("NaN") is non-numeric.
+    // safe_stoi in PacketTypes.cpp recovers with 0.
+    std::unique_ptr<AOPacket> pkt;
+    ASSERT_NO_THROW(pkt = AOPacket::deserialize(webao_wire));
+    ASSERT_NE(pkt, nullptr);
+    EXPECT_EQ(pkt->get_header(), "MS");
+
+    // Dispatching to a client must also succeed and publish a valid IC event
+    // with the fields that parsed cleanly.
+    pkt->handle(cli);
+    auto ev = ch.get_event();
+    ASSERT_TRUE(ev.has_value());
+    EXPECT_EQ(ev->get_character(), "neuro");
+    EXPECT_EQ(ev->get_emote(), "/normal");
+    EXPECT_EQ(ev->get_char_id(), 40);
+    drain(ch);
+}

--- a/tests/ao/net/test_NewPackets.cpp
+++ b/tests/ao/net/test_NewPackets.cpp
@@ -228,8 +228,8 @@ TEST(AOPacketMS, DeserializeWebaoNaNSfxDelayDoesNotThrow) {
     AOClient cli;
     cli.conn_state = CONNECTED;
 
-    constexpr const char* webao_wire =
-        "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = 0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
+    constexpr const char* webao_wire = "MS#1#-#neuro#/normal#test#def#02  = 03  = 04  = 05  = 06  = 07  = 08  = "
+                                       "0#0#40#NaN#0#0#0#0#0##-1#0#0#0#0#-#-#-#0#||#%";
 
     // Constructor must not throw even though field 9 ("NaN") is non-numeric.
     // safe_stoi in PacketTypes.cpp recovers with 0.


### PR DESCRIPTION
## Summary
- **Fixes a server-crashing bug** where webAO sending `MS#...#NaN#...` (field 9 = `sfx_delay`) would terminate the entire kagami process. Root cause: `std::stoi("NaN")` in the `AOPacketMS` constructor threw `std::invalid_argument`, which escaped `AOPacket::deserialize`, escaped `AOServer::on_client_message` (deserialize was called *outside* the try/catch), escaped the worker thread lambda, and called `std::terminate()`.
- **Adds `safe_stoi`** (file-local in `PacketTypes.cpp`, uses `std::from_chars`) and replaces every `std::stoi` in packet constructors. Non-numeric fields now log at `DEBUG` and recover with a default (0 for most, -1 for `EE`/`DE` event IDs). The three ad-hoc `try/catch` blocks around `std::stoi` in `MA`/`EE`/`DE` were redundant and are dropped.
- **Adds `ao_packet::safe_dispatch`** (template in `AOPacket.h`) as the shared deserialize+dispatch boundary. `AOClient::on_message` and `AOServer::on_client_message` both route through it, eliminating the asymmetry where only one side wrapped parse errors in try/catch. Returns a `DispatchResult` enum so `AOServer` can still drive its per-bucket `kagami_ao_errors_total` metrics (`parse` vs `dispatch`).
- `log_bad_packet` redacts non-printable bytes and caps the wire preview at 256 bytes so hostile payloads cannot scramble terminals or inflate log volume.

## Why webAO sends "NaN"
The crash is triggered by `https://miku.pizza/base/characters/neuro/char.ini` — the `[SoundT]` block is malformed (entries `1`-`8` concatenated onto a single line with no newlines). webAO's `parseInt` returns `NaN` when reading `SoundT[1]`, and ships the literal string "NaN" over the wire. AO-SDL's parser is more forgiving and recovers a `2`, which is why AO-SDL clients never triggered the crash.

## Two layers of defense
Either layer alone would stop *this* crash, but both are valuable:

1. **`safe_stoi`** — graceful per-field recovery. A misconfigured char.ini shouldn't drop the entire IC message just because `sfx_delay` is garbage. Logs at `DEBUG` so it doesn't spam operators.
2. **`safe_dispatch`** — boundary protection for *any* exception that escapes a packet constructor or handler. Logs at `WARNING` because by the time we hit this, something is genuinely wrong (missing delimiter, handler bug, unanticipated packet shape).

## Test plan
- [x] `AOPacketSafeDispatch.ValidPacketIsDispatchedOnce` — happy path
- [x] `AOPacketSafeDispatch.ParseErrorIsSwallowed` — missing `#%` delimiter
- [x] `AOPacketSafeDispatch.HandlerExceptionIsSwallowed` — handler throws `std::runtime_error`
- [x] `AOPacketSafeDispatch.WebaoMsNanDoesNotCrash` — exact wire bytes captured from webAO
- [x] `AOPacketMS.DeserializeWebaoNaNSfxDelayDoesNotThrow` — constructor-level regression test that also verifies the resulting `ICMessageEvent` carries the correctly-parsed fields (`char_id=40`, `character="neuro"`, etc.)
- [x] Full suite: **2025/2025 pass across 189 test suites** — no regressions
- [ ] Smoke test against a real webAO client once merged & deployed

## Observability
Post-merge, watch `kagami_ao_errors_total{type="parse"}` and `{type="dispatch"}` on the existing Grafana overview dashboard (`deploy/grafana/provisioning/dashboards/kagami-overview.json`). The metric labels were preserved intentionally so no dashboard changes are required. Any sustained increase after deploy would indicate either malformed-packet activity worth investigating via the new redacted log previews, or a handler regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)