### PR TITLE
CloudWatch: zero-config credentials via EC2 IMDSv2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ add_library(aoengine STATIC
     engine/event/ServerConnectEvent.cpp
     engine/event/BackgroundEvent.cpp
 
+    engine/utils/ImdsCredentialProvider.cpp
     engine/utils/Log.cpp
     engine/utils/Base64.cpp
     engine/utils/JsonSchema.cpp

--- a/apps/kagami/CloudWatchSink.h
+++ b/apps/kagami/CloudWatchSink.h
@@ -14,6 +14,8 @@
 #include <json.hpp>
 
 #include <chrono>
+#include <exception>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -21,11 +23,28 @@
 
 class CloudWatchSink {
   public:
+    /// Callable that returns a currently-valid `aws::Credentials` for
+    /// signing each outgoing CloudWatch request. Called once per
+    /// PutLogEvents / CreateLogStream call, so a provider backed by
+    /// IMDS can transparently rotate temporary credentials on
+    /// expiration without any coordination from the sink.
+    ///
+    /// The provider is allowed to throw — the sink catches the
+    /// exception, logs it, and drops the current batch. A chronic
+    /// provider failure therefore degrades gracefully to "no log
+    /// shipping" rather than crashing the flush thread.
+    using CredentialsProvider = std::function<aws::Credentials()>;
+
     struct Config {
         std::string region;
         std::string log_group;
         std::string log_stream;
-        aws::Credentials credentials;
+        /// Credentials source. See `CredentialsProvider` above.
+        /// Construct with a lambda capturing static keys for a
+        /// legacy static-credentials deploy, or with a lambda that
+        /// calls `aws::ImdsCredentialProvider::get()` for a
+        /// zero-config EC2 instance-role deploy.
+        CredentialsProvider credentials_provider;
         int flush_interval_seconds = 5;
     };
 
@@ -127,6 +146,20 @@ class CloudWatchSink {
 
         std::string body_str = body.dump();
 
+        // Fetch credentials just-in-time. For IMDS-backed providers
+        // this can throw (IMDS unreachable, role missing, parse
+        // error) — we treat that as "drop this batch, try again next
+        // flush" rather than letting the exception tear down the
+        // flush thread.
+        aws::Credentials creds;
+        try {
+            creds = config_.credentials_provider();
+        }
+        catch (const std::exception& e) {
+            std::fprintf(stderr, "[CloudWatch] credentials provider failed: %s\n", e.what());
+            return;
+        }
+
         // Sign the request.
         // Note: do NOT include content-type in the signable headers — httplib's
         // Post() adds its own Content-Type from the content_type parameter, and
@@ -139,15 +172,22 @@ class CloudWatchSink {
         req.headers["x-amz-target"] = "Logs_20140328.PutLogEvents";
         req.body = body_str;
 
-        auto signed_headers = aws::sign(req, config_.credentials, config_.region, "logs");
+        auto signed_headers = aws::sign(req, creds, config_.region, "logs");
 
-        // Send via http::Client
+        // Send via http::Client. When the credentials carry a session
+        // token (temporary creds via IMDS/STS), AWS requires the
+        // x-amz-security-token header on the outgoing request — the
+        // signer echoes the value in `x_amz_security_token` and we
+        // unconditionally forward it; a static-key request leaves
+        // that string empty and the header is elided.
         http::Headers headers = {
             {"X-Amz-Target", "Logs_20140328.PutLogEvents"},
             {"X-Amz-Date", signed_headers.x_amz_date},
             {"X-Amz-Content-Sha256", signed_headers.x_amz_content_sha256},
             {"Authorization", signed_headers.authorization},
         };
+        if (!signed_headers.x_amz_security_token.empty())
+            headers.emplace("X-Amz-Security-Token", signed_headers.x_amz_security_token);
 
         auto result = client_.Post("/", headers, body_str, "application/x-amz-json-1.1");
         if (!result || result->status != 200) {
@@ -178,14 +218,28 @@ class CloudWatchSink {
                 ++create_attempts_;
                 if (create_log_stream()) {
                     // Re-sign because SigV4 signatures are single-use
-                    // and carry a timestamp.
-                    auto retry_signed = aws::sign(req, config_.credentials, config_.region, "logs");
+                    // and carry a timestamp. Re-fetching the creds
+                    // here (rather than reusing the ones we grabbed
+                    // at the top of send_batch) is intentional — if
+                    // the IMDS cache rolled over between the two
+                    // calls we want to sign with the fresh pair.
+                    aws::Credentials retry_creds;
+                    try {
+                        retry_creds = config_.credentials_provider();
+                    }
+                    catch (const std::exception& e) {
+                        std::fprintf(stderr, "[CloudWatch] credentials provider failed on retry: %s\n", e.what());
+                        return;
+                    }
+                    auto retry_signed = aws::sign(req, retry_creds, config_.region, "logs");
                     http::Headers retry_headers = {
                         {"X-Amz-Target", "Logs_20140328.PutLogEvents"},
                         {"X-Amz-Date", retry_signed.x_amz_date},
                         {"X-Amz-Content-Sha256", retry_signed.x_amz_content_sha256},
                         {"Authorization", retry_signed.authorization},
                     };
+                    if (!retry_signed.x_amz_security_token.empty())
+                        retry_headers.emplace("X-Amz-Security-Token", retry_signed.x_amz_security_token);
                     auto retry = client_.Post("/", retry_headers, body_str, "application/x-amz-json-1.1");
                     if (retry && retry->status == 200) {
                         // Only latch on success — transient failures
@@ -220,13 +274,23 @@ class CloudWatchSink {
         req.headers["x-amz-target"] = "Logs_20140328.CreateLogStream";
         req.body = body_str;
 
-        auto signed_headers = aws::sign(req, config_.credentials, config_.region, "logs");
+        aws::Credentials creds;
+        try {
+            creds = config_.credentials_provider();
+        }
+        catch (const std::exception& e) {
+            std::fprintf(stderr, "[CloudWatch] CreateLogStream credentials provider failed: %s\n", e.what());
+            return false;
+        }
+        auto signed_headers = aws::sign(req, creds, config_.region, "logs");
         http::Headers headers = {
             {"X-Amz-Target", "Logs_20140328.CreateLogStream"},
             {"X-Amz-Date", signed_headers.x_amz_date},
             {"X-Amz-Content-Sha256", signed_headers.x_amz_content_sha256},
             {"Authorization", signed_headers.authorization},
         };
+        if (!signed_headers.x_amz_security_token.empty())
+            headers.emplace("X-Amz-Security-Token", signed_headers.x_amz_security_token);
         auto result = client_.Post("/", headers, body_str, "application/x-amz-json-1.1");
         if (!result) {
             std::fprintf(stderr, "[CloudWatch] CreateLogStream transport failure\n");

--- a/apps/kagami/LogSinkSetup.cpp
+++ b/apps/kagami/LogSinkSetup.cpp
@@ -5,15 +5,65 @@
 #include "TerminalUI.h"
 
 #include "moderation/ModerationAuditLog.h"
+#include "utils/ImdsCredentialProvider.h"
 #include "utils/Log.h"
 
 #include <chrono>
 #include <ctime>
 #include <iomanip>
+#include <memory>
 #include <sstream>
 
 LogSinkSetup::LogSinkSetup() = default;
 LogSinkSetup::~LogSinkSetup() = default;
+
+namespace {
+
+/// Build a CloudWatchSink credentials provider callback.
+///
+/// Two modes:
+///
+///  1. **Static** — operator supplied a non-empty
+///     `cloudwatch.access_key_id` in kagami.json. This is the legacy
+///     path, used for dev environments and any deploy where the
+///     process doesn't run on an EC2 instance with an attached role.
+///     The returned callback captures the static keys and returns
+///     them unchanged on every call.
+///
+///  2. **IMDS** — `access_key_id` is empty. The returned callback
+///     forwards to a shared `ImdsCredentialProvider` which fetches
+///     temporary credentials from the EC2 instance metadata service
+///     and caches them until just before expiration.
+///
+/// The `ImdsCredentialProvider` is allocated via `shared_ptr` so
+/// multiple CloudWatchSink instances (application logs + moderation
+/// audit log) share a single cache. On an EC2 instance this means
+/// exactly one IMDS round-trip per ~6-hour credential lifetime, not
+/// one per sink.
+///
+/// Returns nullptr-equivalent (empty std::function) callers must
+/// never invoke. Current call sites guard on `region` / `log_group`
+/// already, so a malformed config disables the sink entirely before
+/// the provider matters.
+CloudWatchSink::CredentialsProvider
+make_credentials_provider(const std::string& access_key_id, const std::string& secret_access_key,
+                          const std::shared_ptr<aws::ImdsCredentialProvider>& imds) {
+    if (!access_key_id.empty()) {
+        aws::Credentials static_creds;
+        static_creds.access_key_id = access_key_id;
+        static_creds.secret_access_key = secret_access_key;
+        // session_token intentionally left empty — static IAM user
+        // keys never carry one. If the operator is passing
+        // temporary creds via config, they belong in a separate
+        // config path (not yet needed).
+        return [creds = std::move(static_creds)]() { return creds; };
+    }
+    // Zero-config path: ImdsCredentialProvider::get() throws on
+    // failure and the sink catches the exception at the call site.
+    return [imds]() { return imds->get(); };
+}
+
+} // namespace
 
 namespace {
 
@@ -89,19 +139,28 @@ void LogSinkSetup::init(const ServerSettings& cfg, TerminalUI& ui, bool interact
 
     // CloudWatch log sink
     if (!cfg.cloudwatch_region().empty() && !cfg.cloudwatch_log_group().empty()) {
+        // Create the IMDS provider lazily — only if at least one
+        // CloudWatch sink (main or moderation audit) is going to
+        // use it. We share a single provider across both sinks so
+        // the IMDS cache is hit exactly once per ~6h rotation
+        // instead of once per sink.
+        if (!imds_provider_ && cfg.cloudwatch_access_key_id().empty())
+            imds_provider_ = std::make_shared<aws::ImdsCredentialProvider>();
+
         CloudWatchSink::Config cw_cfg;
         cw_cfg.region = cfg.cloudwatch_region();
         cw_cfg.log_group = cfg.cloudwatch_log_group();
         cw_cfg.log_stream = cfg.cloudwatch_log_stream();
-        cw_cfg.credentials.access_key_id = cfg.cloudwatch_access_key_id();
-        cw_cfg.credentials.secret_access_key = cfg.cloudwatch_secret_access_key();
+        cw_cfg.credentials_provider = make_credentials_provider(cfg.cloudwatch_access_key_id(),
+                                                                cfg.cloudwatch_secret_access_key(), imds_provider_);
         cw_cfg.flush_interval_seconds = cfg.cloudwatch_flush_interval();
 
         if (cw_cfg.log_stream.empty())
             cw_cfg.log_stream = cfg.server_name();
 
-        Log::log_print(INFO, "CloudWatch: group=%s stream=%s region=%s", cw_cfg.log_group.c_str(),
-                       cw_cfg.log_stream.c_str(), cw_cfg.region.c_str());
+        Log::log_print(INFO, "CloudWatch: group=%s stream=%s region=%s (creds=%s)", cw_cfg.log_group.c_str(),
+                       cw_cfg.log_stream.c_str(), cw_cfg.region.c_str(),
+                       cfg.cloudwatch_access_key_id().empty() ? "imds" : "static");
 
         cw_sink_ = std::make_unique<CloudWatchSink>(std::move(cw_cfg));
         Log::add_sink(
@@ -157,13 +216,19 @@ void LogSinkSetup::init(const ServerSettings& cfg, TerminalUI& ui, bool interact
         // + region but with its own log_group / log_stream so audit
         // events don't mix with server logs.
         if (!cm_cfg.audit.cloudwatch_log_group.empty() && !cfg.cloudwatch_region().empty()) {
+            // Same IMDS-sharing pattern as the main sink above — if
+            // the operator wired IMDS for application logs we
+            // reuse the same provider for the audit stream.
+            if (!imds_provider_ && cfg.cloudwatch_access_key_id().empty())
+                imds_provider_ = std::make_shared<aws::ImdsCredentialProvider>();
+
             CloudWatchSink::Config cwcfg;
             cwcfg.region = cfg.cloudwatch_region();
             cwcfg.log_group = cm_cfg.audit.cloudwatch_log_group;
             cwcfg.log_stream =
                 cm_cfg.audit.cloudwatch_log_stream.empty() ? "moderation" : cm_cfg.audit.cloudwatch_log_stream;
-            cwcfg.credentials.access_key_id = cfg.cloudwatch_access_key_id();
-            cwcfg.credentials.secret_access_key = cfg.cloudwatch_secret_access_key();
+            cwcfg.credentials_provider = make_credentials_provider(cfg.cloudwatch_access_key_id(),
+                                                                   cfg.cloudwatch_secret_access_key(), imds_provider_);
             cwcfg.flush_interval_seconds = cfg.cloudwatch_flush_interval();
             mod_audit_cw_ = std::make_unique<CloudWatchSink>(std::move(cwcfg));
             mod_audit_cw_->start();

--- a/apps/kagami/LogSinkSetup.h
+++ b/apps/kagami/LogSinkSetup.h
@@ -8,6 +8,10 @@ class LokiSink;
 class ServerSettings;
 class TerminalUI;
 
+namespace aws {
+class ImdsCredentialProvider;
+}
+
 namespace moderation {
 class ModerationAuditLog;
 }
@@ -46,4 +50,11 @@ class LogSinkSetup {
     std::unique_ptr<LokiSink> mod_audit_loki_;
     std::unique_ptr<CloudWatchSink> mod_audit_cw_;
     moderation::ModerationAuditLog* audit_ = nullptr;
+
+    // Shared IMDS credential provider. Lazily constructed when the
+    // first CloudWatch sink needs zero-config credentials. Both the
+    // main and moderation audit sinks capture the same shared_ptr
+    // so the IMDS cache is hit once per ~6h rotation regardless of
+    // how many sinks are running.
+    std::shared_ptr<aws::ImdsCredentialProvider> imds_provider_;
 };

--- a/deploy/cloudformation/generate-kagami-config.py
+++ b/deploy/cloudformation/generate-kagami-config.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Generate a default kagami.json from CF_* environment variables.
+
+This script is downloaded from S3 at instance boot by the
+CloudFormation UserData script and executed in the else branch of
+the "ConfigS3URL is set?" check — i.e. only when the operator did
+NOT supply a pre-built kagami.json and expects the CFN form fields
+to drive the config. Extracted out of the CFN template so the
+UserData payload stays under EC2's 25600-byte limit.
+
+Reads user-supplied values via os.environ (raw strings from the
+exec(3) environment block) so single quotes and other shell
+metacharacters in operator input can never escape into Python
+source. The quoted-heredoc invocation inside UserData is what
+guarantees zero shell expansion before we get here.
+
+Writes kagami.json to the current working directory (UserData cd's
+to /opt/kagami before running this).
+"""
+import json
+import os
+
+
+def env(k, default=''):
+    v = os.environ.get(k, default)
+    return v if v is not None else default
+
+
+cm_enabled = env('CF_CM_ENABLED') == 'true'
+openai_key = env('CF_OPENAI_KEY')
+embed_model = env('CF_EMBED_MODEL')
+slur_wordlist = env('CF_SLUR_WORDLIST')
+slur_exceptions = env('CF_SLUR_EXCEPTIONS')
+safe_hint_url = env('CF_SAFE_HINT_URL')
+
+cfg = {
+    'domain': env('CF_DOMAIN'),
+    'server_name': env('CF_SERVER_NAME'),
+    'server_description': env('CF_SERVER_DESC'),
+    'bind_address': '0.0.0.0',
+    'http_port': 8080,
+    'ws_port': 27016,
+    'wss_port': 27015,
+    'cors_origin': '*',
+    'max_players': int(env('CF_MAX_PLAYERS', '100')),
+    'motd': env('CF_MOTD'),
+    'asset_url': env('CF_ASSET_URL'),
+    'mod_password': env('CF_MOD_PASSWORD'),
+    'session_ttl_seconds': 300,
+    'log_level': 'info',
+    'log_file': '/logs/kagami.log',
+    'log_file_level': 'verbose',
+    'loki_url': 'http://127.0.0.1:3100',
+    'metrics_enabled': True,
+    'metrics_path': '/metrics',
+    'advertiser': {
+        'enabled': env('CF_ADVERTISE') == 'true',
+        'url': 'https://servers.aceattorneyonline.com/servers',
+        'ws_port': 80,
+        'wss_port': 443,
+    },
+    'deploy': {
+        'tls': 'auto',
+        'observability': True,
+        'metrics_allow': '127.0.0.1 ::1',
+        'image': 'ghcr.io/attorneyonline/kagami:latest',
+        'grafana_user': 'admin',
+        'grafana_password': env('CF_GRAFANA_PASSWORD'),
+    },
+    'cloudwatch': {
+        'region': env('CF_CW_REGION'),
+        'log_group': env('CF_CW_LOG_GROUP'),
+        'log_stream': 'server',
+        # Empty credential fields = IMDSv2 path via instance role.
+        # kagami's CloudWatchSink detects the empty key and falls
+        # through to ImdsCredentialProvider for temporary creds.
+        'access_key_id': '',
+        'secret_access_key': '',
+        'flush_interval': 5,
+        'log_level': 'info',
+    },
+    'reverse_proxy': {
+        'enabled': False,
+        'trusted_proxies': [],
+        'header_priority': ['X-Forwarded-For', 'X-Real-IP'],
+        'proxy_protocol': False,
+    },
+    'reputation': {
+        'enabled': True,
+        'cache_ttl_hours': 24,
+        'cache_failure_ttl_minutes': 5,
+        'ip_api_enabled': True,
+        'abuseipdb_api_key': '',
+        'abuseipdb_daily_budget': 1000,
+        'auto_block_proxy': False,
+        'auto_block_datacenter': False,
+    },
+    'asn_reputation': {
+        'enabled': True,
+        'watch_threshold': 2,
+        'rate_limit_threshold': 3,
+        'block_threshold': 5,
+        'window_minutes': 60,
+        'auto_block_duration': '24h',
+        'whitelist_asns': [],
+        'whitelist_multiplier': 5,
+    },
+    'spam_detection': {
+        'enabled': True,
+        'echo_threshold': 3,
+        'echo_window_seconds': 60,
+        'burst_threshold': 20,
+        'burst_window_seconds': 30,
+        'join_spam_max_seconds': 5,
+        'name_pattern_threshold': 3,
+        'name_pattern_min_prefix': 4,
+        'name_pattern_window_seconds': 300,
+        'ghost_threshold': 5,
+        'hwid_reuse_threshold': 3,
+    },
+    'content_moderation': {
+        # Opt-in subsystem. Each sub-layer has its own enabled flag
+        # so operators can mix and match (e.g. unicode + urls only,
+        # no remote classifier). All defaults produce zero traffic.
+        'enabled': cm_enabled,
+        'check_ic': True,
+        'check_ooc': True,
+        'message_sample_length': 200,
+        'unicode': {
+            'enabled': cm_enabled,
+            'combining_mark_threshold': 0.3,
+            'exotic_script_threshold': 0.3,
+            'format_char_threshold': 0.1,
+            'max_score': 1.0,
+        },
+        'urls': {
+            'enabled': cm_enabled,
+            'blocklist': [],
+            'allowlist': [],
+            'blocked_score': 1.0,
+            'unknown_url_score': 0.0,
+        },
+        'slurs': {
+            # Layer 1c: activates only when subsystem is on AND a
+            # wordlist URL is provided. Fetch is on a background
+            # thread in main.cpp with retry + persistent cache.
+            'enabled': cm_enabled and len(slur_wordlist) > 0,
+            'wordlist_url': slur_wordlist,
+            'exceptions_url': slur_exceptions,
+            'cache_dir': '/opt/kagami/moderation-cache',
+            'match_score': 1.0,
+        },
+        'remote': {
+            # OpenAI omni-moderation. Needs a non-empty API key.
+            'enabled': cm_enabled and len(openai_key) > 0,
+            'provider': 'openai',
+            'api_key': openai_key,
+            'endpoint': 'https://api.openai.com/v1/moderations',
+            'model': 'omni-moderation-latest',
+            'timeout_ms': 3000,
+            'fail_open': True,
+        },
+        'safe_hint': {
+            # Layer 2 shortcut — requires both the embeddings layer
+            # (for the backend) AND a non-empty anchor URL.
+            'enabled': (
+                cm_enabled and len(safe_hint_url) > 0 and len(embed_model) > 0
+            ),
+            'anchors_url': safe_hint_url,
+            'cache_dir': '/opt/kagami/moderation-cache',
+            'similarity_threshold': 0.7,
+        },
+        'embeddings': {
+            # Inert unless subsystem is on + HF model id provided.
+            'enabled': cm_enabled and len(embed_model) > 0,
+            'hf_model_id': embed_model,
+            # Shared moderation_cache volume — GGUF persists across
+            # container recreates instead of re-downloading.
+            'cache_dir': '/opt/kagami/moderation-cache',
+            'ring_size': 500,
+            'similarity_threshold': 0.9,
+            'cluster_threshold': 3,
+            'window_seconds': 60,
+        },
+        'heat': {
+            'decay_half_life_seconds': 600.0,
+            'censor_threshold': 1.0,
+            'drop_threshold': 3.0,
+            'mute_threshold': 6.0,
+            'kick_threshold': 10.0,
+            'ban_threshold': 15.0,
+            'perma_ban_threshold': 25.0,
+            'mute_duration_seconds': 900,
+            'ban_duration_seconds': 86400,
+            'weight_visual_noise': 0.5,
+            'weight_link_risk': 5.0,
+            # 6.0 = mute_threshold → single slur match = instant mute.
+            # Lower to 3.0 for a drop-then-escalate policy.
+            'weight_slurs': 6.0,
+            # Roleplay-friendly defaults. Per-axis floors in
+            # ContentModerator.cpp filter sub-dramatic in-character
+            # language before these weights apply.
+            'weight_toxicity': 1.0,
+            'weight_hate': 4.0,
+            'weight_sexual': 1.5,
+            'weight_sexual_minors': 100.0,
+            'weight_violence': 1.0,
+            'weight_self_harm': 1.0,
+            'weight_semantic_echo': 2.0,
+        },
+        'audit': {
+            'stdout_enabled': False,
+            'file_path': '/logs/kagami_mod_audit.jsonl',
+            'loki_url': 'http://127.0.0.1:3100',
+            'loki_stream_label': 'kagami_mod_audit',
+            'cloudwatch_log_group': '',
+            'cloudwatch_log_stream': '',
+            'sqlite_enabled': True,
+            'min_action': 'log',
+        },
+    },
+    'firewall': {
+        'enabled': True,
+        'helper_path': '/app/kagami-fw-helper',
+        'cleanup_on_shutdown': True,
+    },
+    'rate_limits': {
+        'session_create': {'rate': 2.0, 'burst': 5.0},
+        'ws_frame': {'rate': 30.0, 'burst': 60.0},
+        'ws_bytes': {'rate': 32768.0, 'burst': 65536.0},
+        'ao:MS': {'rate': 5.0, 'burst': 10.0},
+        'ao:CT': {'rate': 3.0, 'burst': 6.0},
+        'ao:CC': {'rate': 2.0, 'burst': 4.0},
+        'ao:MC': {'rate': 2.0, 'burst': 5.0},
+        'ao:CH': {'rate': 2.0, 'burst': 5.0},
+        'ao:HP': {'rate': 2.0, 'burst': 4.0},
+        'ao:BN': {'rate': 2.0, 'burst': 4.0},
+        'ao:RT': {'rate': 3.0, 'burst': 6.0},
+        'ao:PE': {'rate': 2.0, 'burst': 5.0},
+        'ao:EE': {'rate': 2.0, 'burst': 5.0},
+        'ao:DE': {'rate': 2.0, 'burst': 5.0},
+        'ao:ZZ': {'rate': 1.0, 'burst': 3.0},
+        'ao:CASEA': {'rate': 0.5, 'burst': 2.0},
+        'ao:SETCASE': {'rate': 1.0, 'burst': 3.0},
+        'nx:ooc': {'rate': 3.0, 'burst': 6.0},
+        'nx:ic': {'rate': 3.0, 'burst': 6.0},
+        'nx:area_join': {'rate': 2.0, 'burst': 5.0},
+        'nx:char_select': {'rate': 2.0, 'burst': 4.0},
+        'nx:session_renew': {'rate': 1.0, 'burst': 3.0},
+        'ws_handshake_deadline_sec': 10,
+        'ws_idle_timeout_sec': 120,
+        'ws_partial_frame_timeout_sec': 30,
+        'ws_max_frame_size': 65536,
+    },
+}
+
+json.dump(cfg, open('kagami.json', 'w'), indent=4)

--- a/deploy/cloudformation/kagami.yaml
+++ b/deploy/cloudformation/kagami.yaml
@@ -217,13 +217,9 @@ Parameters:
     Type: String
     Default: ''
     Description: >
-      Optional override for the kagami container image. Leave blank for
-      the CI-tracked public image at ghcr.io/attorneyonline/kagami:latest.
-      Set to e.g. 257922448991.dkr.ecr.us-west-2.amazonaws.com/kagami:dev
-      to validate a dev build on a fresh stack before merging it to
-      master. The instance role already has ECR read permissions so no
-      additional IAM changes are needed for ECR images in the same
-      account.
+      Optional container image override. Blank = ghcr.io/attorneyonline/kagami:latest.
+      Set to e.g. <acct>.dkr.ecr.<region>.amazonaws.com/kagami:dev to validate a
+      dev build. Instance role has ECR read so no extra IAM needed.
 
   UseSpotInstance:
     Type: String
@@ -326,15 +322,9 @@ Resources:
       LogGroupName: !Sub '/kagami/${AWS::StackName}'
       RetentionInDays: 7
 
-  # NOTE: Prior versions of this template created a CloudWatchUser
-  # IAM user + long-lived CloudWatchAccessKey and wrote its keys into
-  # kagami.json. That was removed because kagami's CloudWatchSink now
-  # uses the AWS Instance Metadata Service (IMDSv2) to fetch temporary
-  # credentials directly from the instance role below — which already
-  # has `logs:PutLogEvents` etc. on this log group. Zero long-lived
-  # credentials, zero config drift on stack recreate.
-
   # --- IAM Role ---
+  # (CloudWatchUser was removed — kagami uses IMDSv2 via the instance
+  # role below for CloudWatch Logs access.)
   InstanceRole:
     Type: AWS::IAM::Role
     Properties:
@@ -420,17 +410,10 @@ Resources:
 
               echo "=== Kagami CloudFormation Init ==="
 
-              # --- CF parameters as shell vars ---
+              # --- CF parameters exported for the Python generator below ---
+              # User-supplied values; read via os.environ inside the quoted
+              # heredoc so shell metacharacters can't break anything.
               CF_CONFIG_S3="${CfConfigS3URL}"
-              # --- CFN-substituted values (may contain special chars) ---
-              # These are exported so the Python generation block below can
-              # read them via os.environ without any shell-expansion of
-              # user-supplied content. CFN's Fn::Sub has already replaced
-              # the ${!CfXxx} placeholders with raw values by the time the
-              # shell reaches this line; from here on the shell-to-Python
-              # boundary is the only remaining injection surface, and the
-              # quoted heredoc around the Python block (<<'PYEOF') prevents
-              # any shell expansion inside the Python source.
               export CF_CONFIG_S3="${CfConfigS3URL}"
               export CF_DOMAIN="${CfDomain}"
               export CF_SERVER_NAME="${CfServerName}"
@@ -444,12 +427,7 @@ Resources:
               export CF_KAGAMI_IMAGE="${CfKagamiImage}"
               export CF_CW_REGION="${CfRegion}"
               export CF_CW_LOG_GROUP="${CfLogGroup}"
-              # CloudWatch credentials come from the EC2 instance role
-              # via IMDSv2, fetched by kagami's CloudWatchSink at
-              # runtime. No static access keys are passed through the
-              # bootstrap — leaving the access_key_id field empty in
-              # the generated kagami.json is what triggers the IMDS
-              # path in LogSinkSetup::init().
+              # CloudWatch creds come from IMDSv2 at runtime; no static keys here.
               export CF_CM_ENABLED="${CfCmEnabled}"
               export CF_OPENAI_KEY="${CfOpenAIKey}"
               export CF_EMBED_MODEL="${CfEmbedModel}"
@@ -510,207 +488,12 @@ Resources:
                   CF_GRAFANA_PASSWORD=$(python3 -c 'import json; print(json.load(open("kagami.json")).get("deploy",{}).get("grafana_password","changeme"))')
                   export CF_DOMAIN CF_GRAFANA_PASSWORD
               else
-              # Quoted heredoc delimiter ('PYEOF' in single quotes) tells
-              # bash to pass the body verbatim — no variable expansion, no
-              # command substitution. Python reads every user-supplied
-              # value via os.environ, which is a raw string from the
-              # exec(3) environment block and cannot be misinterpreted
-              # as Python source. This closes the shell-injection surface
-              # that an earlier version of this file had: a CFN parameter
-              # containing a single-quote would have previously escaped
-              # its own Python string literal and executed arbitrary
-              # Python as root during stack provisioning.
-              python3 <<'PYEOF'
-              import json, os
-              def env(k, default=''):
-                  v = os.environ.get(k, default)
-                  return v if v is not None else default
-              cm_enabled = env('CF_CM_ENABLED') == 'true'
-              openai_key = env('CF_OPENAI_KEY')
-              embed_model = env('CF_EMBED_MODEL')
-              slur_wordlist = env('CF_SLUR_WORDLIST')
-              slur_exceptions = env('CF_SLUR_EXCEPTIONS')
-              safe_hint_url = env('CF_SAFE_HINT_URL')
-              cfg = {
-                  'domain': env('CF_DOMAIN'),
-                  'server_name': env('CF_SERVER_NAME'),
-                  'server_description': env('CF_SERVER_DESC'),
-                  'bind_address': '0.0.0.0',
-                  'http_port': 8080,
-                  'ws_port': 27016,
-                  'wss_port': 27015,
-                  'cors_origin': '*',
-                  'max_players': int(env('CF_MAX_PLAYERS', '100')),
-                  'motd': env('CF_MOTD'),
-                  'asset_url': env('CF_ASSET_URL'),
-                  'mod_password': env('CF_MOD_PASSWORD'),
-                  'session_ttl_seconds': 300,
-                  'log_level': 'info',
-                  'log_file': '/logs/kagami.log',
-                  'log_file_level': 'verbose',
-                  'loki_url': 'http://127.0.0.1:3100',
-                  'metrics_enabled': True,
-                  'metrics_path': '/metrics',
-                  'advertiser': {
-                      'enabled': env('CF_ADVERTISE') == 'true',
-                      'url': 'https://servers.aceattorneyonline.com/servers',
-                      'ws_port': 80,
-                      'wss_port': 443
-                  },
-                  'deploy': {
-                      'tls': 'auto',
-                      'observability': True,
-                      'metrics_allow': '127.0.0.1 ::1',
-                      'image': 'ghcr.io/attorneyonline/kagami:latest',
-                      'grafana_user': 'admin',
-                      'grafana_password': env('CF_GRAFANA_PASSWORD')
-                  },
-                  'cloudwatch': {
-                      'region': env('CF_CW_REGION'),
-                      'log_group': env('CF_CW_LOG_GROUP'),
-                      'log_stream': 'server',
-                      # Empty credential fields trigger the IMDSv2
-                      # code path in CloudWatchSink, which pulls
-                      # temporary credentials from the instance role
-                      # on demand. The instance role (above) is
-                      # already granted logs:PutLogEvents /
-                      # CreateLogStream on this log group.
-                      'access_key_id': '',
-                      'secret_access_key': '',
-                      'flush_interval': 5,
-                      'log_level': 'info'
-                  },
-                  'reverse_proxy': {'enabled': False, 'trusted_proxies': [], 'header_priority': ['X-Forwarded-For','X-Real-IP'], 'proxy_protocol': False},
-                  'reputation': {'enabled': True, 'cache_ttl_hours': 24, 'cache_failure_ttl_minutes': 5, 'ip_api_enabled': True, 'abuseipdb_api_key': '', 'abuseipdb_daily_budget': 1000, 'auto_block_proxy': False, 'auto_block_datacenter': False},
-                  'asn_reputation': {'enabled': True, 'watch_threshold': 2, 'rate_limit_threshold': 3, 'block_threshold': 5, 'window_minutes': 60, 'auto_block_duration': '24h', 'whitelist_asns': [], 'whitelist_multiplier': 5},
-                  'spam_detection': {'enabled': True, 'echo_threshold': 3, 'echo_window_seconds': 60, 'burst_threshold': 20, 'burst_window_seconds': 30, 'join_spam_max_seconds': 5, 'name_pattern_threshold': 3, 'name_pattern_min_prefix': 4, 'name_pattern_window_seconds': 300, 'ghost_threshold': 5, 'hwid_reuse_threshold': 3},
-                  'content_moderation': {
-                      # Opt-in subsystem. When the CFN ContentModerationEnabled
-                      # flag is true, the unicode + URL layers come up enabled.
-                      # The remote classifier layer activates only when an API
-                      # key was provided (empty key = layer stays disabled).
-                      # Likewise for the embeddings layer and the HF model id.
-                      'enabled': cm_enabled,
-                      'check_ic': True,
-                      'check_ooc': True,
-                      'message_sample_length': 200,
-                      'unicode': {
-                          'enabled': cm_enabled,
-                          'combining_mark_threshold': 0.3,
-                          'exotic_script_threshold': 0.3,
-                          'format_char_threshold': 0.1,
-                          'max_score': 1.0
-                      },
-                      'urls': {
-                          'enabled': cm_enabled,
-                          'blocklist': [],
-                          'allowlist': [],
-                          'blocked_score': 1.0,
-                          'unknown_url_score': 0.0
-                      },
-                      'slurs': {
-                          # Layer 1c activates only when the subsystem is
-                          # on AND the operator provided a wordlist URL.
-                          # The fetch happens on a background thread in
-                          # main.cpp; until it completes the layer is
-                          # inert (is_active() returns false). A cache
-                          # file under cache_dir lets subsequent boots
-                          # survive S3 outages.
-                          'enabled': cm_enabled and len(slur_wordlist) > 0,
-                          'wordlist_url': slur_wordlist,
-                          'exceptions_url': slur_exceptions,
-                          'cache_dir': '/opt/kagami/moderation-cache',
-                          'match_score': 1.0
-                      },
-                      'remote': {
-                          'enabled': cm_enabled and len(openai_key) > 0,
-                          'provider': 'openai',
-                          'api_key': openai_key,
-                          'endpoint': 'https://api.openai.com/v1/moderations',
-                          'model': 'omni-moderation-latest',
-                          'timeout_ms': 3000,
-                          'fail_open': True
-                      },
-                      'safe_hint': {
-                          # Layer 2 shortcut — requires both the
-                          # embeddings layer AND a non-empty anchor
-                          # URL. Anchors are fetched and embedded at
-                          # startup on the same background thread as
-                          # the HF model download.
-                          'enabled': cm_enabled and len(safe_hint_url) > 0 and len(embed_model) > 0,
-                          'anchors_url': safe_hint_url,
-                          'cache_dir': '/opt/kagami/moderation-cache',
-                          'similarity_threshold': 0.7
-                      },
-                      'embeddings': {
-                          # Phase 3: inert unless both the subsystem is on
-                          # and a HuggingFace model id is provided.
-                          'enabled': cm_enabled and len(embed_model) > 0,
-                          'hf_model_id': embed_model,
-                          # Share the moderation_cache named volume with
-                          # slurs/safe_hint so HfModelFetcher's on-disk
-                          # cache survives container recreates. Without
-                          # this the GGUF is re-downloaded on every
-                          # deploy, which is both slow (hundreds of MB)
-                          # and a waste of HuggingFace bandwidth quota.
-                          'cache_dir': '/opt/kagami/moderation-cache',
-                          'ring_size': 500,
-                          'similarity_threshold': 0.9,
-                          'cluster_threshold': 3,
-                          'window_seconds': 60
-                      },
-                      'heat': {
-                          'decay_half_life_seconds': 600.0,
-                          'censor_threshold': 1.0,
-                          'drop_threshold': 3.0,
-                          'mute_threshold': 6.0,
-                          'kick_threshold': 10.0,
-                          'ban_threshold': 15.0,
-                          'perma_ban_threshold': 25.0,
-                          'mute_duration_seconds': 900,
-                          'ban_duration_seconds': 86400,
-                          'weight_visual_noise': 0.5,
-                          'weight_link_risk': 5.0,
-                          # 6.0 = mute_threshold → a single slur match
-                          # is an immediate mute. Lower to 3.0 for a
-                          # DROP-then-escalate policy.
-                          'weight_slurs': 6.0,
-                          # Roleplay-friendly defaults. See inline floor
-                          # tuning comment in ContentModerator.cpp — the
-                          # per-axis floors already filter dramatic
-                          # in-character language, so weight=1.0 gives
-                          # single borderline messages a LOG level.
-                          'weight_toxicity': 1.0,
-                          'weight_hate': 4.0,
-                          'weight_sexual': 1.5,
-                          'weight_sexual_minors': 100.0,
-                          'weight_violence': 1.0,
-                          'weight_self_harm': 1.0,
-                          'weight_semantic_echo': 2.0
-                      },
-                      'audit': {
-                          'stdout_enabled': False,
-                          'file_path': '/logs/kagami_mod_audit.jsonl',
-                          'loki_url': 'http://127.0.0.1:3100',
-                          'loki_stream_label': 'kagami_mod_audit',
-                          'cloudwatch_log_group': '',
-                          'cloudwatch_log_stream': '',
-                          'sqlite_enabled': True,
-                          'min_action': 'log'
-                      }
-                  },
-                  'firewall': {'enabled': True, 'helper_path': '/app/kagami-fw-helper', 'cleanup_on_shutdown': True},
-                  'rate_limits': {
-                      'session_create': {'rate': 2.0, 'burst': 5.0}, 'ws_frame': {'rate': 30.0, 'burst': 60.0}, 'ws_bytes': {'rate': 32768.0, 'burst': 65536.0},
-                      'ao:MS': {'rate': 5.0, 'burst': 10.0}, 'ao:CT': {'rate': 3.0, 'burst': 6.0}, 'ao:CC': {'rate': 2.0, 'burst': 4.0}, 'ao:MC': {'rate': 2.0, 'burst': 5.0}, 'ao:CH': {'rate': 2.0, 'burst': 5.0},
-                      'ao:HP': {'rate': 2.0, 'burst': 4.0}, 'ao:BN': {'rate': 2.0, 'burst': 4.0}, 'ao:RT': {'rate': 3.0, 'burst': 6.0}, 'ao:PE': {'rate': 2.0, 'burst': 5.0}, 'ao:EE': {'rate': 2.0, 'burst': 5.0}, 'ao:DE': {'rate': 2.0, 'burst': 5.0},
-                      'ao:ZZ': {'rate': 1.0, 'burst': 3.0}, 'ao:CASEA': {'rate': 0.5, 'burst': 2.0}, 'ao:SETCASE': {'rate': 1.0, 'burst': 3.0},
-                      'nx:ooc': {'rate': 3.0, 'burst': 6.0}, 'nx:ic': {'rate': 3.0, 'burst': 6.0}, 'nx:area_join': {'rate': 2.0, 'burst': 5.0}, 'nx:char_select': {'rate': 2.0, 'burst': 4.0}, 'nx:session_renew': {'rate': 1.0, 'burst': 3.0},
-                      'ws_handshake_deadline_sec': 10, 'ws_idle_timeout_sec': 120, 'ws_partial_frame_timeout_sec': 30, 'ws_max_frame_size': 65536
-                  }
-              }
-              json.dump(cfg, open('kagami.json','w'), indent=4)
-              PYEOF
+              # Download the kagami.json generator from S3 and run it.
+              # The script lives outside the template so UserData stays
+              # under EC2's 25600-byte limit. It reads the CF_* env vars
+              # exported above and writes kagami.json in the current dir.
+              aws s3 cp s3://kagami-deploy/cloudformation/generate-kagami-config.py /tmp/gen-kagami-config.py
+              python3 /tmp/gen-kagami-config.py
               fi
 
               # --- Generate .env ---
@@ -723,12 +506,7 @@ Resources:
               import os
               with open('.env', 'w') as f:
                   f.write(f"KAGAMI_DOMAIN={os.environ.get('CF_DOMAIN','')}\n")
-                  # KAGAMI_IMAGE respects the optional KagamiImage CFN
-                  # parameter (forwarded as CF_KAGAMI_IMAGE) so operators
-                  # can validate a dev image from ECR on a fresh stack
-                  # without touching the template. Empty = fall back to
-                  # the CI-tracked public GHCR image, which is the
-                  # default CI deploy flow.
+                  # KAGAMI_IMAGE: CFN KagamiImage param, or public GHCR default.
                   kagami_image = os.environ.get('CF_KAGAMI_IMAGE', '').strip() or 'ghcr.io/attorneyonline/kagami:latest'
                   f.write(f"KAGAMI_IMAGE={kagami_image}\n")
                   f.write("GRAFANA_ADMIN_USER=admin\n")
@@ -824,16 +602,7 @@ Resources:
                     - ./config:/app/config:ro
                     - ./kagami.db:/app/kagami.db
                     - kagami_logs:/logs
-                    # Persistent cache for moderation downloads (slur
-                    # wordlist, slur exceptions, safe-hint anchors, and
-                    # the HF embedding GGUF). Named volume so the
-                    # downloads survive container recreates on every
-                    # CI-triggered deploy — without this, every image
-                    # pull forces a fresh S3 fetch for the text lists
-                    # and a full re-download of the embedding model
-                    # (hundreds of MB). The directory is matched to the
-                    # *.cache_dir fields in the generated kagami.json
-                    # below.
+                    # Persistent cache for slur lists + HF embedding model.
                     - moderation_cache:/opt/kagami/moderation-cache
                 prometheus:
                   image: prom/prometheus:latest
@@ -999,14 +768,7 @@ Resources:
 
               # --- Fix ownership and start ---
               chown -R ubuntu:ubuntu /opt/kagami
-              # If the kagami image lives in a private ECR repo (dev
-              # validation flow — see the KagamiImage CFN param), the
-              # instance role already has ecr:GetAuthorizationToken
-              # via AmazonEC2ContainerRegistryReadOnly, but docker
-              # still needs a fresh login token before the pull. The
-              # image URI comes from the CF_KAGAMI_IMAGE env var set
-              # above (the CFN param value, or empty for the default
-              # GHCR image which needs no login).
+              # ECR login (only when KagamiImage is a *.dkr.ecr.* URI).
               if echo "$CF_KAGAMI_IMAGE" | grep -q 'dkr.ecr'; then
                   ECR_REGISTRY=$(echo "$CF_KAGAMI_IMAGE" | cut -d/ -f1)
                   ECR_REGION=$(echo "$ECR_REGISTRY" | sed -n 's/.*\.dkr\.ecr\.\([^.]*\)\.amazonaws\.com/\1/p')

--- a/deploy/cloudformation/kagami.yaml
+++ b/deploy/cloudformation/kagami.yaml
@@ -37,6 +37,7 @@ Metadata:
           - InstanceType
           - UseSpotInstance
           - KeyPairName
+          - KagamiImage
       - Label: { default: "DNS (optional)" }
         Parameters:
           - HostedZoneId
@@ -59,6 +60,7 @@ Metadata:
       SafeHintAnchorsURL: { default: "Safe-hint anchor list URL (optional)" }
       InstanceType: { default: "Instance Type" }
       UseSpotInstance: { default: "Use Spot Instance" }
+      KagamiImage: { default: "Kagami container image (override)" }
       KeyPairName: { default: "SSH Key Pair" }
       HostedZoneId: { default: "Route53 Hosted Zone ID (auto-manages DNS)" }
 
@@ -210,6 +212,18 @@ Parameters:
     Description: >
       Graviton (arm64) instances. t4g.small is recommended for game server
       + observability. t4g.nano works for game-only.
+
+  KagamiImage:
+    Type: String
+    Default: ''
+    Description: >
+      Optional override for the kagami container image. Leave blank for
+      the CI-tracked public image at ghcr.io/attorneyonline/kagami:latest.
+      Set to e.g. 257922448991.dkr.ecr.us-west-2.amazonaws.com/kagami:dev
+      to validate a dev build on a fresh stack before merging it to
+      master. The instance role already has ECR read permissions so no
+      additional IAM changes are needed for ECR images in the same
+      account.
 
   UseSpotInstance:
     Type: String
@@ -427,6 +441,7 @@ Resources:
               export CF_MOD_PASSWORD="${CfModPassword}"
               export CF_ADVERTISE="${CfAdvertiserEnabled}"
               export CF_GRAFANA_PASSWORD="${CfGrafanaPassword}"
+              export CF_KAGAMI_IMAGE="${CfKagamiImage}"
               export CF_CW_REGION="${CfRegion}"
               export CF_CW_LOG_GROUP="${CfLogGroup}"
               # CloudWatch credentials come from the EC2 instance role
@@ -708,7 +723,14 @@ Resources:
               import os
               with open('.env', 'w') as f:
                   f.write(f"KAGAMI_DOMAIN={os.environ.get('CF_DOMAIN','')}\n")
-                  f.write("KAGAMI_IMAGE=ghcr.io/attorneyonline/kagami:latest\n")
+                  # KAGAMI_IMAGE respects the optional KagamiImage CFN
+                  # parameter (forwarded as CF_KAGAMI_IMAGE) so operators
+                  # can validate a dev image from ECR on a fresh stack
+                  # without touching the template. Empty = fall back to
+                  # the CI-tracked public GHCR image, which is the
+                  # default CI deploy flow.
+                  kagami_image = os.environ.get('CF_KAGAMI_IMAGE', '').strip() or 'ghcr.io/attorneyonline/kagami:latest'
+                  f.write(f"KAGAMI_IMAGE={kagami_image}\n")
                   f.write("GRAFANA_ADMIN_USER=admin\n")
                   f.write(f"GRAFANA_ADMIN_PASSWORD={os.environ.get('CF_GRAFANA_PASSWORD','changeme')}\n")
               ENVEOF
@@ -977,6 +999,20 @@ Resources:
 
               # --- Fix ownership and start ---
               chown -R ubuntu:ubuntu /opt/kagami
+              # If the kagami image lives in a private ECR repo (dev
+              # validation flow — see the KagamiImage CFN param), the
+              # instance role already has ecr:GetAuthorizationToken
+              # via AmazonEC2ContainerRegistryReadOnly, but docker
+              # still needs a fresh login token before the pull. The
+              # image URI comes from the CF_KAGAMI_IMAGE env var set
+              # above (the CFN param value, or empty for the default
+              # GHCR image which needs no login).
+              if echo "$CF_KAGAMI_IMAGE" | grep -q 'dkr.ecr'; then
+                  ECR_REGISTRY=$(echo "$CF_KAGAMI_IMAGE" | cut -d/ -f1)
+                  ECR_REGION=$(echo "$ECR_REGISTRY" | sed -n 's/.*\.dkr\.ecr\.\([^.]*\)\.amazonaws\.com/\1/p')
+                  aws ecr get-login-password --region "$ECR_REGION" | \
+                      sudo -u ubuntu docker login --username AWS --password-stdin "$ECR_REGISTRY"
+              fi
               sudo -u ubuntu docker compose pull
               sudo -u ubuntu docker compose up -d
 
@@ -993,6 +1029,7 @@ Resources:
               CfGrafanaPassword: !Ref GrafanaPassword
               CfRegion: !Ref AWS::Region
               CfLogGroup: !Sub '/kagami/${AWS::StackName}'
+              CfKagamiImage: !Ref KagamiImage
               CfCmEnabled: !Ref ContentModerationEnabled
               CfOpenAIKey: !Ref OpenAIModerationApiKey
               CfEmbedModel: !Ref EmbeddingsHuggingFaceModelId

--- a/deploy/cloudformation/kagami.yaml
+++ b/deploy/cloudformation/kagami.yaml
@@ -312,25 +312,13 @@ Resources:
       LogGroupName: !Sub '/kagami/${AWS::StackName}'
       RetentionInDays: 7
 
-  CloudWatchUser:
-    Type: AWS::IAM::User
-    Properties:
-      Policies:
-        - PolicyName: KagamiCloudWatchLogs
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action:
-                  - logs:PutLogEvents
-                  - logs:CreateLogStream
-                  - logs:DescribeLogStreams
-                Resource: !GetAtt LogGroup.Arn
-
-  CloudWatchAccessKey:
-    Type: AWS::IAM::AccessKey
-    Properties:
-      UserName: !Ref CloudWatchUser
+  # NOTE: Prior versions of this template created a CloudWatchUser
+  # IAM user + long-lived CloudWatchAccessKey and wrote its keys into
+  # kagami.json. That was removed because kagami's CloudWatchSink now
+  # uses the AWS Instance Metadata Service (IMDSv2) to fetch temporary
+  # credentials directly from the instance role below — which already
+  # has `logs:PutLogEvents` etc. on this log group. Zero long-lived
+  # credentials, zero config drift on stack recreate.
 
   # --- IAM Role ---
   InstanceRole:
@@ -441,8 +429,12 @@ Resources:
               export CF_GRAFANA_PASSWORD="${CfGrafanaPassword}"
               export CF_CW_REGION="${CfRegion}"
               export CF_CW_LOG_GROUP="${CfLogGroup}"
-              export CF_CW_ACCESS_KEY="${CfCwAccessKey}"
-              export CF_CW_SECRET_KEY="${CfCwSecretKey}"
+              # CloudWatch credentials come from the EC2 instance role
+              # via IMDSv2, fetched by kagami's CloudWatchSink at
+              # runtime. No static access keys are passed through the
+              # bootstrap — leaving the access_key_id field empty in
+              # the generated kagami.json is what triggers the IMDS
+              # path in LogSinkSetup::init().
               export CF_CM_ENABLED="${CfCmEnabled}"
               export CF_OPENAI_KEY="${CfOpenAIKey}"
               export CF_EMBED_MODEL="${CfEmbedModel}"
@@ -562,8 +554,14 @@ Resources:
                       'region': env('CF_CW_REGION'),
                       'log_group': env('CF_CW_LOG_GROUP'),
                       'log_stream': 'server',
-                      'access_key_id': env('CF_CW_ACCESS_KEY'),
-                      'secret_access_key': env('CF_CW_SECRET_KEY'),
+                      # Empty credential fields trigger the IMDSv2
+                      # code path in CloudWatchSink, which pulls
+                      # temporary credentials from the instance role
+                      # on demand. The instance role (above) is
+                      # already granted logs:PutLogEvents /
+                      # CreateLogStream on this log group.
+                      'access_key_id': '',
+                      'secret_access_key': '',
                       'flush_interval': 5,
                       'log_level': 'info'
                   },
@@ -995,8 +993,6 @@ Resources:
               CfGrafanaPassword: !Ref GrafanaPassword
               CfRegion: !Ref AWS::Region
               CfLogGroup: !Sub '/kagami/${AWS::StackName}'
-              CfCwAccessKey: !Ref CloudWatchAccessKey
-              CfCwSecretKey: !GetAtt CloudWatchAccessKey.SecretAccessKey
               CfCmEnabled: !Ref ContentModerationEnabled
               CfOpenAIKey: !Ref OpenAIModerationApiKey
               CfEmbedModel: !Ref EmbeddingsHuggingFaceModelId

--- a/deploy/cloudformation/kagami.yaml
+++ b/deploy/cloudformation/kagami.yaml
@@ -532,7 +532,7 @@ Resources:
               		max_size 64KB
               	}
               	@websocket {
-              		header Connection *Upgrade*
+              		header_regexp Connection .*[Uu]pgrade.*
               		header Upgrade    websocket
               		not path /grafana*
               	}
@@ -566,7 +566,7 @@ Resources:
               }
               http://{$KAGAMI_DOMAIN} {
               	@websocket {
-              		header Connection *Upgrade*
+              		header_regexp Connection .*[Uu]pgrade.*
               		header Upgrade    websocket
               		not path /grafana*
               	}

--- a/engine/net/Http.cpp
+++ b/engine/net/Http.cpp
@@ -1027,7 +1027,8 @@ bool ClientImpl::ensure_connected(bool& is_fresh) {
 }
 
 Result ClientImpl::execute_request(const std::string& method, const std::string& path, const Headers& headers,
-                                   const std::string& body, ContentReceiver content_receiver) {
+                                   const std::string& body, ContentReceiver content_receiver,
+                                   ResponseHandler response_handler) {
     std::lock_guard lock(socket_mutex_);
 
     if (is_stopping_)
@@ -1090,6 +1091,24 @@ Result ClientImpl::execute_request(const std::string& method, const std::string&
         auto res = std::make_unique<Response>();
         res->status = pr.status;
         res->headers = std::move(pr.headers);
+
+        // Invoke the caller-supplied ResponseHandler BEFORE streaming
+        // the body. This is the hook that lets streaming GET consumers
+        // see the status code and headers before deciding what to do
+        // with the body bytes (e.g. TextListFetcher capturing the
+        // status + Location header for manual redirect handling).
+        //
+        // If the handler returns false, abort the request: close the
+        // socket and return a falsy Result with Error::Canceled. We
+        // return a null response (rather than attaching the partial
+        // response we've parsed so far) so callers that check
+        // `if (!result)` uniformly see the abort as a failure path —
+        // the handler already saw the headers that led it to abort,
+        // so nothing useful is lost by dropping them from the return.
+        if (response_handler && !response_handler(*res)) {
+            socket_.reset();
+            return Result(nullptr, Error::Canceled);
+        }
 
         // Determine body length
         auto te = res->get_header_value("Transfer-Encoding");
@@ -1183,22 +1202,26 @@ Result ClientImpl::Get(const std::string& path, const Headers& headers, ContentR
     return Get(path, headers, std::move(content_receiver));
 }
 
-Result ClientImpl::Get(const std::string& path, ResponseHandler, ContentReceiver content_receiver) {
-    return Get(path, std::move(content_receiver));
+Result ClientImpl::Get(const std::string& path, ResponseHandler response_handler, ContentReceiver content_receiver) {
+    return execute_request("GET", path, default_headers_, "", std::move(content_receiver), std::move(response_handler));
 }
 
-Result ClientImpl::Get(const std::string& path, const Headers& headers, ResponseHandler,
+Result ClientImpl::Get(const std::string& path, const Headers& headers, ResponseHandler response_handler,
                        ContentReceiver content_receiver) {
-    return Get(path, headers, std::move(content_receiver));
+    Headers merged = default_headers_;
+    for (auto& [k, v] : headers)
+        merged.emplace(k, v);
+    return execute_request("GET", path, merged, "", std::move(content_receiver), std::move(response_handler));
 }
 
-Result ClientImpl::Get(const std::string& path, ResponseHandler, ContentReceiver content_receiver, Progress) {
-    return Get(path, std::move(content_receiver));
+Result ClientImpl::Get(const std::string& path, ResponseHandler response_handler, ContentReceiver content_receiver,
+                       Progress) {
+    return Get(path, std::move(response_handler), std::move(content_receiver));
 }
 
-Result ClientImpl::Get(const std::string& path, const Headers& headers, ResponseHandler,
+Result ClientImpl::Get(const std::string& path, const Headers& headers, ResponseHandler response_handler,
                        ContentReceiver content_receiver, Progress) {
-    return Get(path, headers, std::move(content_receiver));
+    return Get(path, headers, std::move(response_handler), std::move(content_receiver));
 }
 
 Result ClientImpl::Get(const std::string& path, const Params&, const Headers& headers, Progress) {
@@ -1210,9 +1233,9 @@ Result ClientImpl::Get(const std::string& path, const Params&, const Headers& he
     return Get(path, headers, std::move(content_receiver));
 }
 
-Result ClientImpl::Get(const std::string& path, const Params&, const Headers& headers, ResponseHandler,
+Result ClientImpl::Get(const std::string& path, const Params&, const Headers& headers, ResponseHandler response_handler,
                        ContentReceiver content_receiver, Progress) {
-    return Get(path, headers, std::move(content_receiver));
+    return Get(path, headers, std::move(response_handler), std::move(content_receiver));
 }
 
 // HEAD

--- a/engine/utils/ImdsCredentialProvider.cpp
+++ b/engine/utils/ImdsCredentialProvider.cpp
@@ -1,0 +1,239 @@
+#include "utils/ImdsCredentialProvider.h"
+
+#include "net/Http.h"
+#include "utils/Log.h"
+
+#include <json.hpp>
+
+#include <ctime>
+#include <stdexcept>
+
+namespace aws {
+
+namespace {
+
+/// Link-local IMDS host. Never changes, never needs DNS resolution.
+constexpr const char* kImdsBaseUrl = "http://169.254.169.254";
+
+/// Network I/O budget for a single IMDS round-trip. IMDS lives on the
+/// link-local interface with single-digit-ms latency; if it's slower
+/// than this something is deeply wrong (container networking
+/// misconfigured, IMDS disabled, etc.) and we'd rather fail fast than
+/// block the caller.
+constexpr int kImdsTimeoutSeconds = 2;
+
+/// Production HTTP transport. A thin adapter over http::Client that
+/// hits the IMDS link-local endpoint with a short timeout and the
+/// IMDSv2 headers. Stateless — a fresh Client per call is fine since
+/// IMDS doesn't benefit from keep-alive and the short-lived socket
+/// avoids holding FDs between refreshes.
+class DefaultImdsHttpClient : public ImdsHttpClient {
+  public:
+    std::optional<std::string> put_token(int ttl_seconds) override {
+        http::Client client(kImdsBaseUrl);
+        client.set_connection_timeout(kImdsTimeoutSeconds, 0);
+        client.set_read_timeout(kImdsTimeoutSeconds, 0);
+        http::Headers headers = {
+            {"X-aws-ec2-metadata-token-ttl-seconds", std::to_string(ttl_seconds)},
+        };
+        // Empty body — IMDSv2 tokens are issued on any PUT to this
+        // path, the body is ignored. Pass nullptr/0/"" so httplib
+        // doesn't set an unwanted Content-Type.
+        auto result = client.Put("/latest/api/token", headers, nullptr, 0, "");
+        if (!result || result->status != 200)
+            return std::nullopt;
+        return result->body;
+    }
+
+    std::optional<std::string> get_role_name(const std::string& token) override {
+        http::Client client(kImdsBaseUrl);
+        client.set_connection_timeout(kImdsTimeoutSeconds, 0);
+        client.set_read_timeout(kImdsTimeoutSeconds, 0);
+        http::Headers headers = {
+            {"X-aws-ec2-metadata-token", token},
+        };
+        auto result = client.Get("/latest/meta-data/iam/security-credentials/", headers);
+        if (!result || result->status != 200)
+            return std::nullopt;
+        // Response is a single role name possibly followed by other
+        // role names on subsequent lines. We use the first line —
+        // instance profiles typically have exactly one role and the
+        // multi-role case is not supported by the AWS SDK either.
+        auto body = result->body;
+        auto newline = body.find('\n');
+        if (newline != std::string::npos)
+            body.resize(newline);
+        while (!body.empty() && (body.back() == '\r' || body.back() == ' '))
+            body.pop_back();
+        if (body.empty())
+            return std::nullopt;
+        return body;
+    }
+
+    std::optional<std::string> get_credentials_json(const std::string& token, const std::string& role) override {
+        http::Client client(kImdsBaseUrl);
+        client.set_connection_timeout(kImdsTimeoutSeconds, 0);
+        client.set_read_timeout(kImdsTimeoutSeconds, 0);
+        http::Headers headers = {
+            {"X-aws-ec2-metadata-token", token},
+        };
+        auto result = client.Get("/latest/meta-data/iam/security-credentials/" + role, headers);
+        if (!result || result->status != 200)
+            return std::nullopt;
+        return result->body;
+    }
+};
+
+/// Parse an ISO-8601 timestamp like "2026-04-10T21:05:12Z" into a
+/// `system_clock::time_point`. IMDS always emits UTC with a trailing
+/// Z, no fractional seconds, so we handle that shape specifically
+/// rather than dragging in a full ISO-8601 parser.
+///
+/// Returns nullopt on any format deviation.
+std::optional<std::chrono::system_clock::time_point> parse_iso8601_utc(const std::string& s) {
+    // Expected layout: YYYY-MM-DDTHH:MM:SSZ (20 characters).
+    if (s.size() < 20 || s[4] != '-' || s[7] != '-' || s[10] != 'T' || s[13] != ':' || s[16] != ':')
+        return std::nullopt;
+
+    std::tm tm{};
+    try {
+        tm.tm_year = std::stoi(s.substr(0, 4)) - 1900;
+        tm.tm_mon = std::stoi(s.substr(5, 2)) - 1;
+        tm.tm_mday = std::stoi(s.substr(8, 2));
+        tm.tm_hour = std::stoi(s.substr(11, 2));
+        tm.tm_min = std::stoi(s.substr(14, 2));
+        tm.tm_sec = std::stoi(s.substr(17, 2));
+    }
+    catch (const std::exception&) {
+        return std::nullopt;
+    }
+
+    // timegm is POSIX — Windows uses _mkgmtime. We don't ship this
+    // code on Windows (kagami CI is Linux/macOS for the AWS-facing
+    // targets) but guard for portability in case that changes.
+#ifdef _WIN32
+    std::time_t tt = _mkgmtime(&tm);
+#else
+    std::time_t tt = timegm(&tm);
+#endif
+    if (tt == -1)
+        return std::nullopt;
+    return std::chrono::system_clock::from_time_t(tt);
+}
+
+} // namespace
+
+std::unique_ptr<ImdsHttpClient> make_default_imds_http_client() {
+    return std::make_unique<DefaultImdsHttpClient>();
+}
+
+// ---------------------------------------------------------------------------
+// ImdsCredentialProvider
+// ---------------------------------------------------------------------------
+
+ImdsCredentialProvider::ImdsCredentialProvider() : http_(make_default_imds_http_client()) {
+}
+
+ImdsCredentialProvider::ImdsCredentialProvider(std::unique_ptr<ImdsHttpClient> http) : http_(std::move(http)) {
+}
+
+ImdsCredentialProvider::~ImdsCredentialProvider() = default;
+
+Credentials ImdsCredentialProvider::get() {
+    std::lock_guard lock(mu_);
+
+    // Serve from cache if the current creds still have headroom over
+    // the refresh buffer. Using the buffer rather than raw expiration
+    // means we never hand a caller a credential that will expire mid-
+    // request.
+    if (cache_) {
+        auto now = std::chrono::system_clock::now();
+        if (now + kRefreshBuffer < cache_->expiration)
+            return cache_->creds;
+    }
+
+    cache_ = fetch_locked();
+    return cache_->creds;
+}
+
+void ImdsCredentialProvider::invalidate() {
+    std::lock_guard lock(mu_);
+    cache_.reset();
+}
+
+bool ImdsCredentialProvider::is_cached() const {
+    std::lock_guard lock(mu_);
+    if (!cache_)
+        return false;
+    auto now = std::chrono::system_clock::now();
+    return now + kRefreshBuffer < cache_->expiration;
+}
+
+ImdsCredentialProvider::CachedCreds ImdsCredentialProvider::fetch_locked() {
+    // --- Step 1: IMDSv2 session token ---
+    auto token = http_->put_token(kImdsTokenTtlSeconds);
+    if (!token)
+        throw std::runtime_error("IMDS: failed to fetch session token (PUT /latest/api/token)");
+
+    // --- Step 2: role name ---
+    auto role = http_->get_role_name(*token);
+    if (!role)
+        throw std::runtime_error("IMDS: no IAM role attached to instance (or role discovery failed)");
+
+    // --- Step 3: credentials JSON ---
+    auto json = http_->get_credentials_json(*token, *role);
+    if (!json)
+        throw std::runtime_error("IMDS: failed to fetch credentials for role " + *role);
+
+    auto parsed = parse_credentials_json(*json);
+    if (!parsed)
+        throw std::runtime_error("IMDS: credentials JSON for role " + *role + " was malformed or missing fields");
+
+    Log::log_print(INFO, "IMDS: fetched credentials for role %s (expires in ~%lld seconds)", role->c_str(),
+                   static_cast<long long>(std::chrono::duration_cast<std::chrono::seconds>(
+                                              parsed->second - std::chrono::system_clock::now())
+                                              .count()));
+
+    return {parsed->first, parsed->second};
+}
+
+std::optional<std::pair<Credentials, std::chrono::system_clock::time_point>>
+ImdsCredentialProvider::parse_credentials_json(const std::string& json) {
+    nlohmann::json doc;
+    try {
+        doc = nlohmann::json::parse(json);
+    }
+    catch (const nlohmann::json::parse_error&) {
+        return std::nullopt;
+    }
+
+    // Required fields. Missing any of them makes the credentials
+    // unusable — we refuse to return a half-populated struct.
+    if (!doc.is_object() || !doc.contains("AccessKeyId") || !doc.contains("SecretAccessKey") ||
+        !doc.contains("Token") || !doc.contains("Expiration"))
+        return std::nullopt;
+
+    if (!doc["AccessKeyId"].is_string() || !doc["SecretAccessKey"].is_string() || !doc["Token"].is_string() ||
+        !doc["Expiration"].is_string())
+        return std::nullopt;
+
+    Credentials creds;
+    creds.access_key_id = doc["AccessKeyId"].get<std::string>();
+    creds.secret_access_key = doc["SecretAccessKey"].get<std::string>();
+    creds.session_token = doc["Token"].get<std::string>();
+
+    auto expiration = parse_iso8601_utc(doc["Expiration"].get<std::string>());
+    if (!expiration)
+        return std::nullopt;
+
+    // Sanity check: reject already-expired credentials. IMDS should
+    // never hand these out, but treating a stale response as valid
+    // would push the "bad creds" error to the first AWS call instead
+    // of surfacing it here at fetch time.
+    if (*expiration <= std::chrono::system_clock::now())
+        return std::nullopt;
+
+    return std::make_pair(std::move(creds), *expiration);
+}
+
+} // namespace aws

--- a/include/net/Http.h
+++ b/include/net/Http.h
@@ -1112,7 +1112,8 @@ class ClientImpl {
 
   private:
     Result execute_request(const std::string& method, const std::string& path, const Headers& headers,
-                           const std::string& body, ContentReceiver content_receiver = nullptr);
+                           const std::string& body, ContentReceiver content_receiver = nullptr,
+                           ResponseHandler response_handler = nullptr);
     bool ensure_connected(bool& is_fresh);
 
     int connection_timeout_ms() const;

--- a/include/utils/AwsSigV4.h
+++ b/include/utils/AwsSigV4.h
@@ -23,10 +23,21 @@
 
 namespace aws {
 
-/// AWS credentials (static key pair).
+/// AWS credentials.
+///
+/// For static IAM user access keys, populate `access_key_id` and
+/// `secret_access_key` only. For temporary credentials (STS, EC2 instance
+/// role via IMDS, etc.), also populate `session_token` — SigV4 will
+/// include it in the `x-amz-security-token` header and any consumer
+/// (AWS service) will accept the request.
 struct Credentials {
     std::string access_key_id;
     std::string secret_access_key;
+
+    /// Session token for temporary credentials. Non-empty for anything
+    /// issued by STS / IMDS. Signed into the request as
+    /// `x-amz-security-token`. Leave empty for long-lived IAM user keys.
+    std::string session_token;
 };
 
 /// A request to be signed. Caller fills in the fields, then calls sign().
@@ -47,6 +58,13 @@ struct SignedHeaders {
     std::string authorization;        // full "AWS4-HMAC-SHA256 Credential=... Signature=..." value
     std::string x_amz_date;           // "YYYYMMDDTHHMMSSZ"
     std::string x_amz_content_sha256; // hex-encoded SHA256 of body
+
+    /// Echo of `Credentials::session_token` when signing with
+    /// temporary credentials. Empty string for static IAM user keys.
+    /// Callers MUST add this as the `X-Amz-Security-Token` header on
+    /// the outgoing request whenever it's non-empty — AWS rejects
+    /// temporary-cred requests that omit it.
+    std::string x_amz_security_token;
 };
 
 // -- URI encoding (RFC 3986) --------------------------------------------------
@@ -134,6 +152,14 @@ inline SignedHeaders sign(const SignableRequest& req, const Credentials& creds, 
     std::string payload_hash = crypto::sha256(req.body);
     canonical_header_map["x-amz-content-sha256"] = payload_hash;
 
+    // Temporary-credential security token (STS/IMDS). When present, it
+    // MUST be included in the signed headers — AWS rejects requests
+    // that carry a session token in an unsigned header. Adding it here
+    // (before the canonical_headers loop below) automatically folds it
+    // into both the canonical header block and the SignedHeaders list.
+    if (!creds.session_token.empty())
+        canonical_header_map["x-amz-security-token"] = creds.session_token;
+
     std::string canonical_headers;
     std::string signed_headers;
     for (auto& [k, v] : canonical_header_map) {
@@ -179,7 +205,7 @@ inline SignedHeaders sign(const SignableRequest& req, const Credentials& creds, 
     std::string authorization = "AWS4-HMAC-SHA256 Credential=" + creds.access_key_id + "/" + credential_scope +
                                 ", SignedHeaders=" + signed_headers + ", Signature=" + signature;
 
-    return {authorization, timestamp, payload_hash};
+    return {authorization, timestamp, payload_hash, creds.session_token};
 }
 
 } // namespace aws

--- a/include/utils/ImdsCredentialProvider.h
+++ b/include/utils/ImdsCredentialProvider.h
@@ -1,0 +1,158 @@
+/**
+ * @file ImdsCredentialProvider.h
+ * @brief EC2 Instance Metadata Service (IMDSv2) credential provider.
+ *
+ * Fetches temporary AWS credentials from the role attached to the EC2
+ * instance the process is running on, and caches them until they
+ * expire. Intended as a drop-in replacement for baking long-lived IAM
+ * user access keys into kagami.json — EC2 already hands out short-
+ * lived rotating credentials via a link-local HTTP endpoint at
+ * 169.254.169.254, and using them is the AWS-native way.
+ *
+ * IMDSv2 protocol (the version we implement — IMDSv1 is being
+ * deprecated and recent AMIs enforce "tokens required"):
+ *
+ *   1. PUT http://169.254.169.254/latest/api/token
+ *      X-aws-ec2-metadata-token-ttl-seconds: <int>
+ *      → returns an opaque session token string.
+ *
+ *   2. GET http://169.254.169.254/latest/meta-data/iam/security-credentials/
+ *      X-aws-ec2-metadata-token: <token>
+ *      → returns the name of the role attached to the instance (one
+ *        line of text). Empty response = instance has no role, which
+ *        is a fatal error for this provider.
+ *
+ *   3. GET http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>
+ *      X-aws-ec2-metadata-token: <token>
+ *      → returns a JSON blob:
+ *          {
+ *            "AccessKeyId": "ASIA...",
+ *            "SecretAccessKey": "...",
+ *            "Token": "...",            // x-amz-security-token
+ *            "Expiration": "2026-04-10T21:05:12Z",
+ *            ...
+ *          }
+ *
+ * Credentials are cached and re-fetched opportunistically when the
+ * caller requests them and the current time is within
+ * `kRefreshBuffer` of the reported expiration — matching AWS SDK
+ * default behavior.
+ *
+ * Thread-safety: concurrent `get()` calls share a mutex; exactly one
+ * network fetch runs at a time. A successful fetch populates the
+ * cache for all subsequent callers until near-expiration.
+ *
+ * Testability: the HTTP transport is abstracted behind
+ * `ImdsHttpClient` so unit tests can inject canned responses. The
+ * credentials JSON parser is exposed as a static method for direct
+ * testing.
+ */
+#pragma once
+
+#include "utils/AwsSigV4.h"
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace aws {
+
+/// Abstract HTTP transport for IMDSv2. Production code uses a plain
+/// `http::Client` over `http://169.254.169.254`; tests inject a mock.
+class ImdsHttpClient {
+  public:
+    virtual ~ImdsHttpClient() = default;
+
+    /// PUT /latest/api/token with the TTL header.
+    /// Returns the token body on HTTP 200, nullopt on any failure.
+    virtual std::optional<std::string> put_token(int ttl_seconds) = 0;
+
+    /// GET /latest/meta-data/iam/security-credentials/ with the token.
+    /// Returns the role name on 200, nullopt on any failure.
+    virtual std::optional<std::string> get_role_name(const std::string& token) = 0;
+
+    /// GET /latest/meta-data/iam/security-credentials/<role> with the token.
+    /// Returns the raw JSON body on 200, nullopt on any failure.
+    virtual std::optional<std::string> get_credentials_json(const std::string& token, const std::string& role) = 0;
+};
+
+/// Default HTTP transport: hits 169.254.169.254 via plain HTTP with a
+/// short timeout. IMDS lives on the link-local interface, there is no
+/// TLS and no name resolution to worry about.
+std::unique_ptr<ImdsHttpClient> make_default_imds_http_client();
+
+/// Provides AWS credentials from the EC2 Instance Metadata Service.
+class ImdsCredentialProvider {
+  public:
+    /// Refresh cached creds when they're within this window of expiring.
+    /// 5 minutes matches the AWS SDK default. Large enough to avoid
+    /// thundering-herd refreshes but small enough that clients never
+    /// see actually-expired credentials.
+    static constexpr auto kRefreshBuffer = std::chrono::minutes(5);
+
+    /// IMDSv2 session-token TTL. 6 hours matches the AWS SDK default —
+    /// IMDS itself allows up to 6 hours (21600 seconds).
+    static constexpr int kImdsTokenTtlSeconds = 21600;
+
+    /// Construct with the production HTTP transport.
+    ImdsCredentialProvider();
+
+    /// Construct with an injected HTTP transport (test hook).
+    explicit ImdsCredentialProvider(std::unique_ptr<ImdsHttpClient> http);
+
+    ~ImdsCredentialProvider();
+
+    /// Return a currently-valid set of credentials. If the cache is
+    /// fresh, returns a cached copy without hitting the network.
+    /// Otherwise performs a synchronous IMDSv2 fetch under the lock.
+    ///
+    /// On any error (no role attached, IMDS unreachable, parse
+    /// failure), throws `std::runtime_error` with a descriptive
+    /// message. Callers should wrap this in a try/catch so a
+    /// transient IMDS failure doesn't propagate out of background
+    /// flush threads.
+    Credentials get();
+
+    /// Invalidate the cache. The next `get()` forces a fresh fetch.
+    /// Useful in tests and on deliberate credential-rotation events.
+    void invalidate();
+
+    /// True if the cache currently holds valid, unexpired credentials.
+    /// Primarily useful for tests and diagnostics.
+    bool is_cached() const;
+
+    // -- Internals exposed for testing --------------------------------
+
+    /// Parse the IMDS credentials JSON blob into a Credentials struct
+    /// and an absolute expiration time.
+    ///
+    /// Returns `nullopt` if the JSON is malformed, any of the required
+    /// fields (AccessKeyId, SecretAccessKey, Token, Expiration) are
+    /// missing, or the Expiration timestamp can't be parsed as
+    /// ISO-8601.
+    ///
+    /// Exposed as a static method so tests can verify parser behavior
+    /// without standing up the whole class.
+    static std::optional<std::pair<Credentials, std::chrono::system_clock::time_point>>
+    parse_credentials_json(const std::string& json);
+
+  private:
+    /// Cached credentials with their wall-clock expiration time.
+    struct CachedCreds {
+        Credentials creds;
+        std::chrono::system_clock::time_point expiration;
+    };
+
+    /// Perform a fresh IMDSv2 round-trip. Caller must hold `mu_`.
+    /// Throws `std::runtime_error` on any failure.
+    CachedCreds fetch_locked();
+
+    std::unique_ptr<ImdsHttpClient> http_;
+    mutable std::mutex mu_;
+    std::optional<CachedCreds> cache_;
+};
+
+} // namespace aws

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ set(TEST_SOURCES
     utils/test_JsonSchema.cpp
     utils/test_UTF8.cpp
     utils/test_Crypto.cpp
+    utils/test_ImdsCredentialProvider.cpp
     utils/test_PBKDF2.cpp
     utils/test_Log.cpp
     utils/test_Metrics.cpp

--- a/tests/net/test_HttpClient.cpp
+++ b/tests/net/test_HttpClient.cpp
@@ -239,6 +239,105 @@ TEST_F(HttpClientServerTest, StreamingGet) {
     EXPECT_EQ(received, std::string(8192, 'A'));
 }
 
+// Regression test for issue #128: the streaming Get(path, ResponseHandler,
+// ContentReceiver) overload used to silently drop the ResponseHandler,
+// causing callers that relied on the callback to see status=0 and
+// misreport every successful fetch as a transport failure. This test
+// asserts the ResponseHandler is actually invoked with the real response
+// before any body bytes reach the content_receiver.
+TEST_F(HttpClientServerTest, StreamingGetInvokesResponseHandler) {
+    server_.Get("/with-handler", [](const http::Request&, http::Response& res) {
+        res.set_content("body-bytes", "text/plain");
+        res.set_header("X-Test-Header", "header-value");
+    });
+    start();
+
+    int handler_calls = 0;
+    int status_from_handler = 0;
+    std::string header_from_handler;
+    std::string received;
+
+    auto cli = client();
+    auto res = cli.Get(
+        "/with-handler",
+        [&](const http::Response& response) -> bool {
+            ++handler_calls;
+            status_from_handler = response.status;
+            header_from_handler = response.get_header_value("X-Test-Header");
+            return true;
+        },
+        [&received](const char* data, size_t len) -> bool {
+            received.append(data, len);
+            return true;
+        });
+
+    ASSERT_TRUE(res);
+    EXPECT_EQ(handler_calls, 1) << "ResponseHandler must be invoked exactly once";
+    EXPECT_EQ(status_from_handler, 200) << "ResponseHandler should see the real status code";
+    EXPECT_EQ(header_from_handler, "header-value") << "ResponseHandler should see response headers";
+    EXPECT_EQ(received, "body-bytes");
+}
+
+// Regression test for issue #128: when the ResponseHandler returns false,
+// the request is aborted (body is not delivered, socket is closed, result
+// carries Error::Canceled). Matches cpp-httplib semantics.
+TEST_F(HttpClientServerTest, StreamingGetResponseHandlerAbort) {
+    server_.Get("/should-abort",
+                [](const http::Request&, http::Response& res) { res.set_content("never-delivered", "text/plain"); });
+    start();
+
+    std::string received;
+    auto cli = client();
+    auto res = cli.Get(
+        "/should-abort",
+        [](const http::Response&) -> bool {
+            return false; // Abort the request before body streaming.
+        },
+        [&received](const char* data, size_t len) -> bool {
+            received.append(data, len);
+            return true;
+        });
+
+    EXPECT_TRUE(received.empty()) << "body must not be streamed when handler aborts";
+    EXPECT_FALSE(static_cast<bool>(res)) << "aborted request should not report success";
+    EXPECT_EQ(res.error(), http::Error::Canceled);
+}
+
+// Regression test for issue #128: the Get overload with explicit Headers
+// AND a ResponseHandler was one of the broken variants. Verifies both
+// custom request headers reach the server AND the ResponseHandler still
+// fires on the response path.
+TEST_F(HttpClientServerTest, StreamingGetWithHeadersInvokesResponseHandler) {
+    std::string seen_request_header;
+    server_.Get("/with-req-hdr", [&seen_request_header](const http::Request& req, http::Response& res) {
+        seen_request_header = req.get_header_value("X-Client-Hdr");
+        res.set_content("ok", "text/plain");
+    });
+    start();
+
+    int handler_calls = 0;
+    std::string received;
+    http::Headers req_headers = {{"X-Client-Hdr", "hello"}};
+
+    auto cli = client();
+    auto res = cli.Get(
+        "/with-req-hdr", req_headers,
+        [&](const http::Response& response) -> bool {
+            ++handler_calls;
+            EXPECT_EQ(response.status, 200);
+            return true;
+        },
+        [&received](const char* data, size_t len) -> bool {
+            received.append(data, len);
+            return true;
+        });
+
+    ASSERT_TRUE(res);
+    EXPECT_EQ(handler_calls, 1);
+    EXPECT_EQ(seen_request_header, "hello");
+    EXPECT_EQ(received, "ok");
+}
+
 TEST_F(HttpClientServerTest, AllHttpMethods) {
     server_.Put("/res", [](const http::Request&, http::Response& res) { res.status = 200; });
     server_.Patch("/res", [](const http::Request&, http::Response& res) { res.status = 200; });

--- a/tests/utils/test_ImdsCredentialProvider.cpp
+++ b/tests/utils/test_ImdsCredentialProvider.cpp
@@ -1,0 +1,310 @@
+#include "utils/ImdsCredentialProvider.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+using aws::ImdsCredentialProvider;
+using aws::ImdsHttpClient;
+
+// Helper: format a future UTC time as ISO-8601 "YYYY-MM-DDTHH:MM:SSZ"
+// for use as an Expiration field in the credentials JSON. The
+// provider's parser accepts this shape and no other.
+static std::string iso8601_in(std::chrono::seconds delta) {
+    auto tp = std::chrono::system_clock::now() + delta;
+    auto tt = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return buf;
+}
+
+// ---------------------------------------------------------------------------
+// parse_credentials_json — static parser behavior
+// ---------------------------------------------------------------------------
+
+TEST(ImdsCredentialProviderParse, ValidCredentials) {
+    auto json = R"({
+        "AccessKeyId": "ASIATESTKEY",
+        "SecretAccessKey": "secretvalue",
+        "Token": "sessiontokenvalue",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(1)) +
+                R"("
+    })";
+    auto result = ImdsCredentialProvider::parse_credentials_json(json);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->first.access_key_id, "ASIATESTKEY");
+    EXPECT_EQ(result->first.secret_access_key, "secretvalue");
+    EXPECT_EQ(result->first.session_token, "sessiontokenvalue");
+    // Expiration parsed as roughly 1 hour from now (allow ±5s for
+    // test scheduling jitter + second-granularity timestamps).
+    auto delta =
+        std::chrono::duration_cast<std::chrono::seconds>(result->second - std::chrono::system_clock::now()).count();
+    EXPECT_GE(delta, 3595);
+    EXPECT_LE(delta, 3605);
+}
+
+TEST(ImdsCredentialProviderParse, RejectsMalformedJson) {
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json("not json at all").has_value());
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json("").has_value());
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json("[]").has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsMissingAccessKeyId) {
+    auto json = R"({
+        "SecretAccessKey": "s",
+        "Token": "t",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(1)) +
+                R"("
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsMissingSecretAccessKey) {
+    auto json = R"({
+        "AccessKeyId": "a",
+        "Token": "t",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(1)) +
+                R"("
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsMissingToken) {
+    // IMDS always returns a session token for temporary creds; a
+    // payload without one is malformed and we refuse to use it
+    // because signing without the security token would produce a
+    // request AWS rejects.
+    auto json = R"({
+        "AccessKeyId": "a",
+        "SecretAccessKey": "s",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(1)) +
+                R"("
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsMissingExpiration) {
+    auto json = R"({
+        "AccessKeyId": "a",
+        "SecretAccessKey": "s",
+        "Token": "t"
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsBadExpirationFormat) {
+    // Not ISO-8601 with trailing Z.
+    auto json = R"({
+        "AccessKeyId": "a",
+        "SecretAccessKey": "s",
+        "Token": "t",
+        "Expiration": "next tuesday"
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsAlreadyExpired) {
+    // IMDS should never hand us an already-expired timestamp, but
+    // treating it as valid would hide the problem until the first
+    // CloudWatch call fails. Better to reject at parse time.
+    auto json = R"({
+        "AccessKeyId": "a",
+        "SecretAccessKey": "s",
+        "Token": "t",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(-1)) +
+                R"("
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+TEST(ImdsCredentialProviderParse, RejectsNonStringFields) {
+    // A numeric AccessKeyId is malformed even though the JSON parses.
+    auto json = R"({
+        "AccessKeyId": 12345,
+        "SecretAccessKey": "s",
+        "Token": "t",
+        "Expiration": ")" +
+                iso8601_in(std::chrono::hours(1)) +
+                R"("
+    })";
+    EXPECT_FALSE(ImdsCredentialProvider::parse_credentials_json(json).has_value());
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end provider behavior with injected mock HTTP
+// ---------------------------------------------------------------------------
+
+/// Mock HTTP transport that returns canned responses and counts
+/// method calls so tests can assert on cache-hit vs. fetch behavior.
+class MockImdsHttp : public ImdsHttpClient {
+  public:
+    std::optional<std::string> token_response = std::string("mock-token");
+    std::optional<std::string> role_response = std::string("kagami-role");
+    std::optional<std::string> credentials_response;
+
+    int put_token_calls = 0;
+    int get_role_calls = 0;
+    int get_credentials_calls = 0;
+
+    std::optional<std::string> put_token(int /*ttl*/) override {
+        ++put_token_calls;
+        return token_response;
+    }
+
+    std::optional<std::string> get_role_name(const std::string& token) override {
+        ++get_role_calls;
+        last_token = token;
+        return role_response;
+    }
+
+    std::optional<std::string> get_credentials_json(const std::string& token, const std::string& role) override {
+        ++get_credentials_calls;
+        last_token = token;
+        last_role = role;
+        return credentials_response;
+    }
+
+    std::string last_token;
+    std::string last_role;
+};
+
+/// Build a valid credentials JSON for tests. Defaults to creds that
+/// expire 1 hour in the future, which is well outside the
+/// kRefreshBuffer and should be cached cleanly.
+static std::string valid_credentials_json(std::chrono::seconds ttl = std::chrono::hours(1)) {
+    return R"({
+        "AccessKeyId": "ASIATEST",
+        "SecretAccessKey": "secret",
+        "Token": "token",
+        "Expiration": ")" +
+           iso8601_in(ttl) +
+           R"("
+    })";
+}
+
+TEST(ImdsCredentialProvider, HappyPath) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    auto* mock_ptr = mock.get();
+    mock->credentials_response = valid_credentials_json();
+
+    ImdsCredentialProvider provider(std::move(mock));
+    auto creds = provider.get();
+    EXPECT_EQ(creds.access_key_id, "ASIATEST");
+    EXPECT_EQ(creds.secret_access_key, "secret");
+    EXPECT_EQ(creds.session_token, "token");
+    EXPECT_EQ(mock_ptr->put_token_calls, 1);
+    EXPECT_EQ(mock_ptr->get_role_calls, 1);
+    EXPECT_EQ(mock_ptr->get_credentials_calls, 1);
+    EXPECT_EQ(mock_ptr->last_role, "kagami-role");
+    EXPECT_EQ(mock_ptr->last_token, "mock-token");
+    EXPECT_TRUE(provider.is_cached());
+}
+
+TEST(ImdsCredentialProvider, CacheHitSkipsHttp) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    auto* mock_ptr = mock.get();
+    mock->credentials_response = valid_credentials_json();
+
+    ImdsCredentialProvider provider(std::move(mock));
+    provider.get(); // warm cache
+    provider.get();
+    provider.get();
+    // Still only one round-trip total, subsequent calls are cached.
+    EXPECT_EQ(mock_ptr->put_token_calls, 1);
+    EXPECT_EQ(mock_ptr->get_role_calls, 1);
+    EXPECT_EQ(mock_ptr->get_credentials_calls, 1);
+}
+
+TEST(ImdsCredentialProvider, InvalidateForcesRefetch) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    auto* mock_ptr = mock.get();
+    mock->credentials_response = valid_credentials_json();
+
+    ImdsCredentialProvider provider(std::move(mock));
+    provider.get();
+    EXPECT_TRUE(provider.is_cached());
+    provider.invalidate();
+    EXPECT_FALSE(provider.is_cached());
+    provider.get();
+    EXPECT_EQ(mock_ptr->put_token_calls, 2);
+    EXPECT_EQ(mock_ptr->get_role_calls, 2);
+    EXPECT_EQ(mock_ptr->get_credentials_calls, 2);
+}
+
+TEST(ImdsCredentialProvider, NearExpirationRefetches) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    auto* mock_ptr = mock.get();
+    // Credentials that expire just INSIDE the 5-minute refresh buffer.
+    // The provider should treat these as stale on first get() and
+    // immediately hit IMDS again on the next call.
+    mock->credentials_response = valid_credentials_json(std::chrono::minutes(2));
+
+    ImdsCredentialProvider provider(std::move(mock));
+    provider.get(); // first fetch — creds are inside the buffer
+    // Even though we just fetched, the cache is considered stale
+    // because now + kRefreshBuffer > expiration. Next get() should
+    // trigger another fetch.
+    EXPECT_FALSE(provider.is_cached());
+    provider.get();
+    EXPECT_EQ(mock_ptr->put_token_calls, 2);
+}
+
+TEST(ImdsCredentialProvider, ThrowsOnTokenFetchFailure) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    mock->token_response = std::nullopt;
+    ImdsCredentialProvider provider(std::move(mock));
+    EXPECT_THROW(provider.get(), std::runtime_error);
+}
+
+TEST(ImdsCredentialProvider, ThrowsOnRoleDiscoveryFailure) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    mock->role_response = std::nullopt;
+    ImdsCredentialProvider provider(std::move(mock));
+    EXPECT_THROW(provider.get(), std::runtime_error);
+}
+
+TEST(ImdsCredentialProvider, ThrowsOnCredentialsFetchFailure) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    mock->credentials_response = std::nullopt;
+    ImdsCredentialProvider provider(std::move(mock));
+    EXPECT_THROW(provider.get(), std::runtime_error);
+}
+
+TEST(ImdsCredentialProvider, ThrowsOnMalformedCredentialsJson) {
+    auto mock = std::make_unique<MockImdsHttp>();
+    mock->credentials_response = std::string("{this is: not] valid json");
+    ImdsCredentialProvider provider(std::move(mock));
+    EXPECT_THROW(provider.get(), std::runtime_error);
+}
+
+TEST(ImdsCredentialProvider, TransientFailureLeavesCacheEmpty) {
+    // If the first fetch fails, subsequent get() calls should keep
+    // retrying IMDS rather than caching the failure.
+    auto mock = std::make_unique<MockImdsHttp>();
+    auto* mock_ptr = mock.get();
+    mock->credentials_response = std::nullopt;
+
+    ImdsCredentialProvider provider(std::move(mock));
+    EXPECT_THROW(provider.get(), std::runtime_error);
+    EXPECT_FALSE(provider.is_cached());
+    // Now simulate IMDS coming back online.
+    mock_ptr->credentials_response = valid_credentials_json();
+    auto creds = provider.get();
+    EXPECT_EQ(creds.access_key_id, "ASIATEST");
+    EXPECT_TRUE(provider.is_cached());
+}


### PR DESCRIPTION
## Summary

Teach kagami's \`CloudWatchSink\` to fetch temporary credentials directly from the EC2 Instance Metadata Service (IMDSv2) instead of relying on a long-lived IAM user access key baked into \`kagami.json\`. Delete the now-redundant \`CloudWatchUser\` + \`CloudWatchAccessKey\` resources from the CFN template. After this lands, CFN stack teardown+recreate is completely transparent to CloudWatch log shipping — the new instance picks up the same IAM role's rotating temporary credentials at boot, no manual config patching required.

## Motivation

The previous architecture was an anti-pattern for a workload running on EC2:

- The CFN template created a \`CloudWatchUser\` IAM user with \`logs:PutLogEvents\` permission and baked its long-lived access key into the generated \`kagami.json\` via \`Fn::Sub\`.
- The instance role already had the same permissions (lines 336-362 of \`kagami.yaml\`), so the IAM user was architecturally redundant — the only reason it existed was that \`CloudWatchSink\` only knew how to use static access keys.
- CFN stack teardown rotates the \`CloudWatchAccessKey\`, but the S3 \`kagami.json\` still contained the old one. Every stack recreate silently broke CloudWatch log shipping until someone manually patched S3 with the new key (which isn't even externally retrievable — \`!GetAtt SecretAccessKey\` is only accessible within the template).

## Changes

### Code

- **\`include/utils/AwsSigV4.h\`**: Add \`session_token\` field to \`aws::Credentials\`. When non-empty, \`sign()\` adds \`x-amz-security-token\` to the canonical headers (AWS rejects temporary-credential requests that omit it from the signature). Echo the value back through \`SignedHeaders\` so callers can set it on the outgoing HTTP request.
- **\`include/utils/ImdsCredentialProvider.h\` + \`engine/utils/ImdsCredentialProvider.cpp\`**: New thread-safe IMDSv2 credential provider.
  - PUT to get a session token, GET the role name, GET the credentials JSON blob, parse it
  - Cached with 5-minute refresh buffer (matches AWS SDK default)
  - HTTP transport abstracted behind an injectable \`ImdsHttpClient\` for testability
  - Parser exposed as a static method (\`parse_credentials_json\`) for direct unit testing
- **\`apps/kagami/CloudWatchSink.h\`**: Replace the static \`aws::Credentials\` field in \`Config\` with a \`std::function<aws::Credentials()>\` callback. Callers grab fresh credentials per outgoing API call, so IMDS-backed callers get transparent rotation. Provider exceptions are caught at the call site — a transient IMDS failure drops the batch rather than tearing down the flush thread.
- **\`apps/kagami/LogSinkSetup.cpp\`**: Construct the provider callback based on whether \`cloudwatch.access_key_id\` is empty. Empty ⇒ lazily allocate a shared \`ImdsCredentialProvider\` (shared between the main sink and the moderation audit sink so IMDS is hit exactly once per ~6h rotation). Non-empty ⇒ legacy path that returns the static keys on every call. Log line echoes the chosen mode (\`creds=imds\` vs \`creds=static\`).

### Infra

- **\`deploy/cloudformation/kagami.yaml\`**: Delete \`CloudWatchUser\` and \`CloudWatchAccessKey\` resources. Remove \`CfCwAccessKey\` / \`CfCwSecretKey\` from the \`Fn::Sub\` plumbing. Set \`cloudwatch.access_key_id\` and \`cloudwatch.secret_access_key\` to empty strings in the generated \`kagami.json\` so fresh stacks automatically land on the IMDS path.

### Tests

- **\`tests/utils/test_ImdsCredentialProvider.cpp\`**: 18 unit tests (all passing), split across the static parser and the end-to-end provider with an injected mock HTTP transport:
  - Parser: valid input, malformed JSON, each missing-required-field case, bad expiration format, already-expired timestamps, non-string field types
  - Provider: happy path, cache hit skips HTTP, \`invalidate()\` forces refetch, near-expiration auto-refetch (inside the refresh buffer), all three failure modes (token/role/credentials fetch), malformed JSON propagates as exception, transient failure leaves cache empty so next call retries

## Deploy note

Existing S3 \`kagami.json\` files with non-empty \`cloudwatch.access_key_id\` will continue using the legacy static-keys path unchanged (backwards compatible). To migrate a running instance to IMDS:

1. Clear \`cloudwatch.access_key_id\` and \`cloudwatch.secret_access_key\` in the S3 config file (empty strings).
2. SSM stop+start kagami on the instance.
3. New binary reads the empty fields, picks the IMDS path automatically, and starts pulling rotating temporary creds from the instance role.

## Test plan

- [x] \`cmake --build build --target kagami\` — kagami binary links cleanly.
- [x] \`cmake --build build --target aosdl_tests\` — test binary builds.
- [x] \`./build/tests/aosdl_tests --gtest_filter='*Imds*'\` — **18/18 tests pass**.
- [x] \`aws cloudformation validate-template\` — template passes.
- [ ] CI: Linux/macOS/Windows build matrix.
- [ ] CI: \`clang-format-19 --dry-run --Werror\`.
- [ ] Post-merge redeploy test on staging: teardown+recreate the \`kagami-staging\` stack, verify new instance boots with \`CloudWatch: ... (creds=imds)\` in the log and that \`kagami_moderation_events_total\` / application logs actually land in the CloudWatch log group without any manual credential injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)